### PR TITLE
feat(lenses): add semantic-fidelity lens

### DIFF
--- a/skills/holtz/references/lens-registry.md
+++ b/skills/holtz/references/lens-registry.md
@@ -39,3 +39,9 @@ Users can add custom lenses by appending new sections following the same four-fi
 **Audit priorities:** Functions that promise behavior their implementation doesn't deliver, version drift in interfaces
 **Failure modes:** Contract violations that callers silently tolerate until they don't
 **Entry point:** Compare documented/typed interfaces against actual implementation behavior
+
+## semantic-fidelity
+**Focus:** Whether names (states, functions, variables, enums) accurately describe what they represent at runtime
+**Audit priorities:** State machine labels vs actual entry/exit timing, function names vs observed behavior, boolean semantics vs toggle points, enum values vs runtime meaning
+**Failure modes:** States labeled for current activity but applied on completion, functions named for actions they don't perform, naming that drifts from semantics across files (same state name means different things to caller vs callee)
+**Entry point:** For each state machine or status enum: trace when each value is set and cleared across ALL callers; compare the temporal window of each value against its documented description. Ask: "If I look at this value right now, does its name tell me the truth about what's happening?"


### PR DESCRIPTION
## Summary

Adds a new `semantic-fidelity` lens to the lens registry. This lens checks whether names — states, functions, variables, enums — accurately describe what they represent at runtime.

## Why this lens is needed

The existing six lenses (`component`, `integration`, `security`, `error-propagation`, `data-flow`, `contract`) all examine code-structural properties: correctness, contracts, error flow, data transformations, security boundaries. None of them reason about **temporal semantics** — whether a name tells the truth about what's happening *at the moment you observe it*.

This gap was discovered during a real audit that converged clean across all six lenses, yet missed a significant design flaw.

## The bug that exposed the gap

A project using a six-state kanban state machine (`todo → design → dev → review → integration → done`) had states applied on **exit** instead of **entry**. The workflow documentation instructed:

1. Do all design work (create branch, open draft PR, write notes)
2. *Then* transition to `design` state

This meant when you looked at the board and saw a story in `design`, the design work was already **done** — the implementer was doing TDD or about to start. Every state label was one phase behind reality. The board was a history log, not a live dashboard.

The code was functionally correct. Stories flowed through the pipeline. Tests passed. All six existing lenses came back clean because:

- **component** checked individual functions — each was correct in isolation
- **integration** checked module contracts — they agreed with each other
- **contract** checked API signatures — implementations matched their interfaces
- The state machine code itself was solid (transition validation, preconditions, WIP limits, atomic writes, locking)

The bug wasn't in the code. It was in the **semantic contract between names and behavior**. The state was called "design" but it didn't represent design-in-progress. No lens asked: "Does this name tell the truth about what's happening right now?"

## What the lens does

The `semantic-fidelity` lens adds a specific audit focus:

- **For state machines:** trace when each state is entered and exited across all callers. Compare the temporal window against the documented description. Flag states where the name describes current activity but the transition fires on completion.
- **For functions:** compare the name's semantic implication against the actual behavior. Flag `is_valid()` that checks completeness, `save()` that only queues, `initialize()` that also starts processing.
- **For booleans/enums:** check when values are toggled vs what the name implies. Flag `is_loading` set when loading finishes, `has_error` cleared before error check completes.

The core audit question: "If I observe this value/name right now, does it tell me the truth about the current state of the system?"

## How it improves Holtz convergence

This lens fills a category gap. The existing lenses cover:
- Structural correctness (component, integration)
- Behavioral contracts (contract, data-flow, error-propagation)
- Security properties (security)

None cover **naming fidelity** — whether the human-readable labels on code constructs accurately reflect their runtime semantics. Convergence currently means "all structural and behavioral properties verified." With this lens, convergence also means "all names describe what they actually do."

🤖 Generated with [Claude Code](https://claude.com/claude-code)