### PR TITLE
feat(lenses): add temporal-protocol lens

### DIFF
--- a/skills/holtz/references/lens-registry.md
+++ b/skills/holtz/references/lens-registry.md
@@ -45,3 +45,9 @@ Users can add custom lenses by appending new sections following the same four-fi
 **Audit priorities:** State machine labels vs actual entry/exit timing, function names vs observed behavior, boolean semantics vs toggle points, enum values vs runtime meaning
 **Failure modes:** States labeled for current activity but applied on completion, functions named for actions they don't perform, naming that drifts from semantics across files (same state name means different things to caller vs callee)
 **Entry point:** For each state machine or status enum: trace when each value is set and cleared across ALL callers; compare the temporal window of each value against its documented description. Ask: "If I look at this value right now, does its name tell me the truth about what's happening?"
+
+## temporal-protocol
+**Focus:** Multi-file orchestration sequences — the actual order of operations vs documented/intended order
+**Audit priorities:** State transitions that fire before/after their documented trigger point, transient states with no meaningful duration between entry and exit, operations that assume prior operations completed but don't verify, workflow steps documented in one file but executed differently in another
+**Failure modes:** Exit-labeled states (transition fires after work instead of before), double-tap transitions (two consecutive state changes with no work between), phantom states (entered and exited in the same code block — never observable), protocol drift between orchestrator docs and agent docs
+**Entry point:** Pick a workflow that spans 2+ files. Trace the actual execution sequence step by step. At each state change, ask: "What work happened since the last state change? What work remains before the next? Is there a state that exists for zero work?"


### PR DESCRIPTION
## Summary

Adds a new `temporal-protocol` lens to the lens registry. This lens traces multi-file orchestration sequences to verify that the actual order of operations matches the documented and intended order.

## Why this lens is needed

The existing lens registry covers structural properties (component, integration), behavioral contracts (contract, data-flow, error-propagation), and security surfaces. None trace a workflow **across file boundaries** to check whether the execution sequence makes temporal sense — whether each step happens at the right moment relative to the steps around it.

This matters because modern codebases often distribute a single workflow across multiple files: an orchestrator document, agent templates, reference protocols, and the code itself. Each file can be internally consistent while the *protocol connecting them* has ordering bugs that no single-file analysis will catch.

## The bug that exposed the gap

A kanban state machine had six states: `todo → design → dev → review → integration → done`. The workflow was documented across four files (orchestrator SKILL.md, story-execution.md reference, implementer.md agent template, kanban-protocol.md). Each file was internally correct.

But the **REVIEW → INTEGRATION** section in story-execution.md looked like this:

```
1. Confirm CI is green
2. Run verification suite
3. Squash-merge the PR
3.5. kanban.py transition {story_id} integration    ← enter integration
4. kanban.py transition {story_id} done              ← immediately enter done
5. Update burndown
```

Steps 3.5 and 4 fire in immediate succession. The merge happens in step 3 while the story is still in `review` state. Then `integration` is entered and `done` is entered with **zero work between them**. The `integration` state is a phantom — entered and exited in the same code block, never observable on the board.

This is one instance of a broader pattern: the **double-tap transition**. Two consecutive state changes with no work between them reveal that one state is semantically empty. In this case, the root cause was exit-labeled states (transitions firing after work instead of before), which compressed `integration` into a transient blip.

All six existing lenses missed this because:
- **component** audited `kanban.py` — the transition function, validation, and preconditions were all correct
- **contract** verified that the documented transitions matched the code's transition table — they did
- **integration** checked module contracts — `kanban.py` and `story-execution.md` agreed on the allowed transitions

No lens traced the actual execution sequence across files to ask: "Is there a state that exists for zero work?"

## What the lens does

The `temporal-protocol` lens audits orchestration sequences by:

1. **Selecting a workflow** that spans 2+ files (state machine usage, agent dispatch protocol, multi-service choreography)
2. **Tracing actual execution order** step by step across all files involved
3. **At each state change**, asking three questions:
   - What work happened since the last state change?
   - What work remains before the next state change?
   - Is there a state/step that exists for zero work?
4. **Flagging temporal anomalies:**
   - **Double-tap transitions** — two consecutive state changes with no work between
   - **Phantom states** — entered and exited in the same code block, never observable
   - **Exit-labeled states** — transition fires after the work it supposedly represents
   - **Protocol drift** — orchestrator docs describe a sequence that agent docs implement differently

## How it improves Holtz convergence

The existing lenses verify that individual components are correct and that module contracts agree. But they audit **structure**, not **sequence**. A workflow can have correct components, valid contracts, and passing tests while the execution ordering makes entire states meaningless.

This lens adds temporal reasoning to convergence. A codebase isn't converged if it contains phantom states, double-tap transitions, or protocol drift between orchestrator and agent documentation — even if every structural and behavioral lens comes back clean.

Pairs well with `semantic-fidelity` (proposed in PR #1), which catches the related class of bugs where names don't match runtime meaning. Together they cover the "when" and "what" dimensions of naming accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)