### PR TITLE
chore: release v0.112.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.111.1",
+  "version": "0.112.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.112.0",
+  "version": "0.112.1",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.109.0",
+  "version": "0.110.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.111.0",
+  "version": "0.111.1",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.110.0",
+  "version": "0.111.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.108.0",
+  "version": "0.109.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.107.0",
+  "version": "0.108.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.112.1] - 2026-04-07
+
+_Changes since v0.107.0_
+
+### Added
+- **enforcement:** upgrade sahjhan to 0.10.0
+- **enforcement:** stop hook allows stop on terminated audit
+- **enforcement:** primer detects daemon death, no restart
+- **enforcement:** daemon death terminates audit, never restarts
+- **enforcement:** add terminated marker and init-pid helpers
+
+### Fixed
+- **enforcement:** fix doubled timezone suffix in terminated marker
+- **enforcement:** fix Python 3.10 compat in _common.py
+
+### Infrastructure
+- update test badge count to 1013
+
 ## [0.107.0] - 2026-04-05
 
 _Changes since v0.102.0_

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/jbrjake/holtz/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/jbrjake/holtz/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)
-![1005 tests](https://img.shields.io/badge/tests-1005_total-brightgreen.svg)
+![1013 tests](https://img.shields.io/badge/tests-1013_total-brightgreen.svg)
 ![80% coverage](https://img.shields.io/badge/coverage-80%25-brightgreen.svg)
 
 **Adversarial TDD audit loop for Claude Code.** Dual auditors find bugs, write failing tests, fix them, and repeat until two consecutive passes find nothing new.

--- a/enforcement/hooks/_common.py
+++ b/enforcement/hooks/_common.py
@@ -17,6 +17,7 @@ import json
 import os
 import socket
 import subprocess
+from datetime import datetime, timezone
 
 _HOOKS_COMMON = os.path.join(
     os.path.dirname(__file__), '..', '..', 'hooks', '_common.py'
@@ -248,3 +249,59 @@ def record_authed_event(
     for k, v in fields.items():
         cmd.extend(["--field", f"{k}={v}"])
     return subprocess.run(cmd, capture_output=True, text=True, cwd=cwd, timeout=10)
+
+
+def _read_init_pid(cwd: str) -> int | None:
+    """Read the daemon PID recorded at audit initialization.
+
+    Returns None if the file is missing or corrupt. This PID identifies
+    the specific daemon instance that holds the session key — if this
+    PID is dead, the key is gone and the audit is unrecoverable.
+    """
+    pid_file = os.path.join(cwd, "docs", "holtz", ".sahjhan", "daemon-init-pid")
+    try:
+        with open(pid_file, encoding="utf-8") as f:
+            return int(f.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _is_process_alive(pid: int) -> bool:
+    """Check if a process is alive using signal 0."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
+
+
+def _write_terminated_marker(
+    cwd: str,
+    init_pid: int,
+    detected_by: str = "unknown",
+) -> None:
+    """Write the audit-terminated marker and update enforcement cache.
+
+    Called when daemon death is detected. The marker file prevents
+    repeated PID checks on subsequent hook invocations. The cache
+    update ensures stop_hook allows stop.
+    """
+    data_dir = os.path.join(cwd, "docs", "holtz", ".sahjhan")
+    marker = os.path.join(data_dir, "terminated")
+    with open(marker, "w", encoding="utf-8") as f:
+        f.write(f"reason: daemon_pid_dead\n")
+        f.write(f"init_pid: {init_pid}\n")
+        f.write(f"detected_by: {detected_by}\n")
+        f.write(f"detected_at: {datetime.now(timezone.utc).isoformat()}Z\n")
+
+    cache_path = os.path.join(data_dir, "enforcement-cache.json")
+    try:
+        with open(cache_path, encoding="utf-8") as f:
+            cache = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        cache = {}
+    cache["state"] = "terminated"
+    cache["terminated_reason"] = "daemon_pid_dead"
+    cache["active"] = False
+    with open(cache_path, "w", encoding="utf-8") as f:
+        json.dump(cache, f)

--- a/enforcement/hooks/_common.py
+++ b/enforcement/hooks/_common.py
@@ -289,10 +289,11 @@ def _write_terminated_marker(
     data_dir = os.path.join(cwd, "docs", "holtz", ".sahjhan")
     marker = os.path.join(data_dir, "terminated")
     with open(marker, "w", encoding="utf-8") as f:
-        f.write(f"reason: daemon_pid_dead\n")
+        f.write("reason: daemon_pid_dead\n")
         f.write(f"init_pid: {init_pid}\n")
         f.write(f"detected_by: {detected_by}\n")
-        f.write(f"detected_at: {datetime.now(timezone.utc).isoformat()}Z\n")
+        ts = datetime.now(timezone.utc).isoformat()  # noqa: UP017
+        f.write(f"detected_at: {ts}Z\n")
 
     cache_path = os.path.join(data_dir, "enforcement-cache.json")
     try:

--- a/enforcement/hooks/_common.py
+++ b/enforcement/hooks/_common.py
@@ -292,8 +292,8 @@ def _write_terminated_marker(
         f.write("reason: daemon_pid_dead\n")
         f.write(f"init_pid: {init_pid}\n")
         f.write(f"detected_by: {detected_by}\n")
-        ts = datetime.now(timezone.utc).isoformat()  # noqa: UP017
-        f.write(f"detected_at: {ts}Z\n")
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")  # noqa: UP017
+        f.write(f"detected_at: {ts}\n")
 
     cache_path = os.path.join(data_dir, "enforcement-cache.json")
     try:

--- a/enforcement/hooks/_daemon_lifecycle.py
+++ b/enforcement/hooks/_daemon_lifecycle.py
@@ -1,27 +1,31 @@
 #!/usr/bin/env python3
-"""Daemon lifecycle supervisor — ensures sahjhan daemon is running during active audits.
+"""Daemon lifecycle — detects daemon death and terminates audit.
 
 PreToolUse hook that:
 - Detects active audit (docs/holtz/.sahjhan/ exists)
-- Writes active-run marker if missing (scans docs/holtz/runs/ for highest run)
-- Checks daemon health via PID probe (os.kill(pid, 0))
-- Starts daemon if dead or missing
-- Blocks if restart fails during an active, fresh audit (via exit_enforcement_error)
+- Checks terminated marker (fast path for already-dead audits)
+- Verifies the init-PID daemon is still alive
+- If dead: writes terminated marker, blocks all tool use
+- Never restarts the daemon — a new daemon has a new key
+
+The daemon holds the HMAC session key exclusively in memory.
+Daemon death = key loss = ledger unwritable = audit is over.
 """
 from __future__ import annotations
 
+import contextlib
 import os
 import re
-import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from _resolve import ensure_sahjhan  # noqa: E402
-
 from _common import (  # noqa: E402
     _active_ledger,
-    exit_enforcement_error,
+    _is_process_alive,
+    _read_init_pid,
+    _write_terminated_marker,
+    exit_block,
     exit_ok,
     read_event,
     write_active_run_marker,
@@ -43,84 +47,52 @@ def _find_highest_run(cwd: str) -> str | None:
     return f"run-{highest}" if highest >= 0 else None
 
 
-def _daemon_pid(cwd: str) -> int | None:
-    """Read the daemon PID from daemon.pid, or None if missing/invalid."""
-    pid_file = os.path.join(cwd, "docs", "holtz", ".sahjhan", "daemon.pid")
-    try:
-        with open(pid_file, encoding="utf-8") as f:
-            return int(f.read().strip())
-    except (OSError, ValueError):
-        return None
-
-
-def _is_process_alive(pid: int) -> bool:
-    """Check if a process is alive using signal 0."""
-    try:
-        os.kill(pid, 0)
-        return True
-    except (OSError, ProcessLookupError):
-        return False
-
-
-def _start_daemon(cwd: str) -> bool:
-    """Attempt to start the sahjhan daemon. Returns True on success."""
-    binary = ensure_sahjhan()
-    if binary is None:
-        return False
-    try:
-        from _common import resolve_config_dir
-        config_dir, _ = resolve_config_dir(cwd)
-        result = subprocess.run(
-            [binary, "--config-dir", config_dir, "daemon", "start"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            cwd=cwd,
-        )
-        if result.returncode == 0:
-            # Verify daemon is actually alive after claiming success
-            pid = _daemon_pid(cwd)
-            return pid is not None and _is_process_alive(pid)
-        return False
-    except (OSError, subprocess.TimeoutExpired):
-        return False
+def _ensure_active_run_marker(cwd: str) -> None:
+    """Write active-run marker if missing."""
+    ledger = _active_ledger(cwd)
+    if ledger is not None:
+        return
+    ledger = _find_highest_run(cwd)
+    if ledger is None:
+        return
+    with contextlib.suppress(OSError):
+        write_active_run_marker(cwd, ledger)
 
 
 def main() -> None:
     event = read_event()
     cwd = event.get("cwd", os.getcwd())
 
-    # No active audit — nothing to do
     data_dir = os.path.join(cwd, "docs", "holtz", ".sahjhan")
     if not os.path.isdir(data_dir):
         exit_ok()
 
-    # Ensure active-run marker exists
-    ledger = _active_ledger(cwd)
-    if ledger is None:
-        ledger = _find_highest_run(cwd)
-        if ledger is None:
-            exit_ok()  # No runs exist — data dir is stale or pre-init
-        try:
-            write_active_run_marker(cwd, ledger)
-        except OSError:
-            exit_ok()
+    # Already terminated — block immediately
+    terminated = os.path.join(data_dir, "terminated")
+    if os.path.isfile(terminated):
+        exit_block(
+            "AUDIT TERMINATED: daemon died — session key lost. "
+            "The audit cannot be completed. /stop to exit."
+        )
 
-    # Check daemon health
-    pid = _daemon_pid(cwd)
-    if pid is not None and _is_process_alive(pid):
-        exit_ok()  # Daemon is healthy
+    # Check init PID
+    init_pid = _read_init_pid(cwd)
+    if init_pid is None:
+        # No init PID tracked — legacy audit or pre-init.
+        exit_ok()
 
-    # Daemon is down or missing — attempt start
-    started = _start_daemon(cwd)
-    if not started:
-        # Double-check: daemon still dead after restart attempt?
-        pid = _daemon_pid(cwd)
-        if pid is None or not _is_process_alive(pid):
-            exit_enforcement_error(
-                cwd, "Daemon restart failed — enforcement cannot evaluate"
-            )
-    exit_ok()
+    # Init PID exists — is it still alive?
+    if _is_process_alive(init_pid):
+        _ensure_active_run_marker(cwd)
+        exit_ok()
+
+    # Init PID is dead. Audit is over.
+    _write_terminated_marker(cwd, init_pid, detected_by="_daemon_lifecycle")
+    exit_block(
+        f"AUDIT TERMINATED: daemon (PID {init_pid}) died — session key lost, "
+        "ledger unwritable. The audit cannot be completed. "
+        "/stop to exit."
+    )
 
 
 if __name__ == "__main__":

--- a/enforcement/hooks/_resolve.py
+++ b/enforcement/hooks/_resolve.py
@@ -11,15 +11,15 @@ from urllib.request import urlopen
 
 # ── Pinned version and integrity checksums ──
 
-SAHJHAN_VERSION = "0.9.0"
+SAHJHAN_VERSION = "0.10.0"
 _RELEASE_BASE = "https://github.com/jbrjake/sahjhan/releases/download"
 _BOOTSTRAP_COOLDOWN = 3600  # seconds before retrying after failure
 
 SAHJHAN_CHECKSUMS: dict[str, str] = {
-    "aarch64-apple-darwin": "93acb65a79bee1ae7caf24c1f6c82f384b907188916b6f51421816704276ff8e",
-    "x86_64-apple-darwin": "ca32ff0df6ed839d10504c5fb5206b008b405aaf03ea6e8c3d534fddba283ebe",
-    "x86_64-unknown-linux-gnu": "7f6d99a5b662091ed9f9c2b06bcba346775fc46af7fe53c3c3bc7dbb43901755",
-    "aarch64-unknown-linux-gnu": "f5a48a0a266709ee84bbb4a880d7ea6cebec7a4357ff3088421c1a424df249cc",
+    "aarch64-apple-darwin": "4b1cc138261a0b00c80e5d50101aae655173c6bb4f066a64a62d16e128739837",
+    "x86_64-apple-darwin": "01f85e78fe600f1557958c52cb68d6791a41cf1279a7fab8e61401524be9e7ac",
+    "x86_64-unknown-linux-gnu": "7425325bb5291e66f429383b80b21ebc3ed4d91760307f30cc3f65befdbbeafb",
+    "aarch64-unknown-linux-gnu": "8aab48f760c67d2e440d570a5fe220084030133a02e5718a2f0f087bab45c085",
 }
 
 # ── Platform resolution ──

--- a/enforcement/hooks/primer.py
+++ b/enforcement/hooks/primer.py
@@ -2,12 +2,13 @@
 """Sahjhan primer — injects resume context on UserPromptSubmit.
 
 When there's an active non-terminal Sahjhan run, this hook:
-1. Records a context_reset event (used by awaiting_clear gate)
-2. Injects current protocol state as additional context
+1. Checks for terminated audit (daemon died)
+2. Records a context_reset event (used by awaiting_clear gate)
+3. Injects current protocol state as additional context
 
-This replaces convergence_primer.py. The context_reset event is
-critical — the awaiting_clear→fix_loop transition gates on it,
-ensuring /clear boundaries are actually observed.
+If the daemon is dead and the init PID confirms death, writes a
+terminated marker and injects a termination message. No restart
+attempts — a new daemon has a new key, the old ledger is sealed.
 """
 from __future__ import annotations
 
@@ -23,28 +24,15 @@ from _resolve import ensure_sahjhan  # noqa: E402
 
 from _common import (  # noqa: E402
     _active_ledger,
+    _is_process_alive,
+    _read_init_pid,
+    _write_terminated_marker,
     exit_ok,
     exit_warn,
     read_event,
     record_authed_event,
     resolve_config_dir,
 )
-
-
-def _try_restart_daemon(cwd: str, binary: str) -> bool:
-    """Attempt to restart the sahjhan daemon. Returns True on success."""
-    try:
-        config_dir, _ = resolve_config_dir(cwd)
-        result = subprocess.run(
-            [binary, "--config-dir", config_dir, "daemon", "start"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            cwd=cwd,
-        )
-        return result.returncode == 0
-    except (OSError, subprocess.TimeoutExpired):
-        return False
 
 
 def main() -> None:
@@ -61,6 +49,15 @@ def main() -> None:
     data_dir = os.path.join(cwd, "docs", "holtz", ".sahjhan")
     if not os.path.isdir(data_dir):
         exit_ok()
+
+    # Terminated audit — inject termination message, skip everything else
+    terminated = os.path.join(data_dir, "terminated")
+    if os.path.isfile(terminated):
+        exit_warn(
+            "AUDIT TERMINATED: daemon died — session key lost. "
+            "The ledger is unwritable. This audit cannot be completed. "
+            "Use /stop to exit, then start a new audit."
+        )
 
     # Get current status
     ledger = _active_ledger(cwd)
@@ -90,9 +87,10 @@ def main() -> None:
     if is_terminal or not current_state:
         exit_ok()
 
-    # Record context_reset event (gates awaiting_clear→fix_loop)
+    # Record context_reset event (gates awaiting_clear -> fix_loop)
     run_number = (ledger or "").replace("run-", "") or "0"
     context_reset_failed = False
+    audit_terminated = False
     try:
         record_authed_event(
             "context_reset",
@@ -106,27 +104,21 @@ def main() -> None:
             ledger=ledger,
         )
     except (OSError, subprocess.TimeoutExpired, RuntimeError):
-        # Daemon may be down — attempt restart and retry once
-        if _try_restart_daemon(cwd, binary):
-            try:
-                record_authed_event(
-                    "context_reset",
-                    {
-                        "project": "holtz",
-                        "run": run_number,
-                        "auditor": "holtz",
-                        "trigger": "user_prompt_submit",
-                    },
-                    cwd=cwd,
-                    ledger=ledger,
-                )
-            except (OSError, subprocess.TimeoutExpired, RuntimeError):
-                context_reset_failed = True
-        else:
-            context_reset_failed = True
+        # Don't restart. Check if daemon init PID is dead.
+        init_pid = _read_init_pid(cwd)
+        if init_pid is not None and not _is_process_alive(init_pid):
+            _write_terminated_marker(cwd, init_pid, detected_by="primer")
+            audit_terminated = True
+        context_reset_failed = True
 
-    # Build resume context — use ledger-derived run number (consistent with context_reset event)
-    # status text does not include run_number; derive from ledger name.
+    if audit_terminated:
+        exit_warn(
+            "AUDIT TERMINATED: daemon died during awaiting_clear — session key lost. "
+            "The ledger is unwritable. This audit cannot be completed. "
+            "Use /stop to exit, then start a new audit."
+        )
+
+    # Build resume context
     perspective = status.get("current_perspective", "unknown")
     available = status.get("available_transitions", [])
 
@@ -155,7 +147,7 @@ def main() -> None:
     if context_reset_failed:
         context += (
             "\nWARNING: context_reset recording failed — daemon may not be running. "
-            f"Start it with `{binary} daemon start`, then re-run `/clear`."
+            "If the daemon is dead, the audit cannot be completed."
         )
 
     context += f"\nSahjhan binary: {binary}"

--- a/enforcement/hooks/stop_hook.py
+++ b/enforcement/hooks/stop_hook.py
@@ -63,6 +63,12 @@ def main() -> None:
     if not _has_active_audit(cwd):
         exit_stop_allow()
 
+    # Terminated audit — always allow stop
+    terminated = os.path.join(cwd, "docs", "holtz", ".sahjhan", "terminated")
+    if os.path.isfile(terminated):
+        _try_stop_daemon(cwd)
+        exit_stop_allow()
+
     # Read enforcement cache directly (no subprocess, no timeout)
     cache = read_cache(cwd)
 

--- a/enforcement/trusted-callers.toml
+++ b/enforcement/trusted-callers.toml
@@ -6,7 +6,7 @@
 # CI gate: the pre-commit hook verifies this manifest is up to date.
 
 [callers]
-"enforcement/hooks/_common.py" = "sha256:6da08f1c331ca5fe07eef7a2a7ed67e937cccf5d65e3d687da45ae1cce6436f7"
+"enforcement/hooks/_common.py" = "sha256:038eb28f0c56de00f6484a1bceb081d9f91da699ebac5264b9f667b462fb964f"
 "enforcement/hooks/lens_quiz.py" = "sha256:dd8cec7c74483eca6e6ec0dc7aa70514e2b1e481c51ace2a9254ccdcfc78073e"
 "enforcement/hooks/stop_hook.py" = "sha256:95ee01ec189b4328daeafa1083d7ef1e5007878600b53145af07c3704748dbb1"
 "enforcement/hooks/primer.py" = "sha256:f29c8616469768ba6eeaa1ce7cdc3edd2c8df56e4be18f59b93a99c18e4e9196"

--- a/enforcement/trusted-callers.toml
+++ b/enforcement/trusted-callers.toml
@@ -6,8 +6,8 @@
 # CI gate: the pre-commit hook verifies this manifest is up to date.
 
 [callers]
-"enforcement/hooks/_common.py" = "sha256:4d6120ef553b80f15a68e1727252347557337f5e807db68fed282764f1510a5c"
+"enforcement/hooks/_common.py" = "sha256:6da08f1c331ca5fe07eef7a2a7ed67e937cccf5d65e3d687da45ae1cce6436f7"
 "enforcement/hooks/lens_quiz.py" = "sha256:dd8cec7c74483eca6e6ec0dc7aa70514e2b1e481c51ace2a9254ccdcfc78073e"
-"enforcement/hooks/stop_hook.py" = "sha256:739564601ab666b6c53cb21e34856359fff136aeeae39473c6326b6b4bd702a6"
-"enforcement/hooks/primer.py" = "sha256:02fcad96be20e7f8c85d412ea72047126a2a98b9a6db96bcfc23ff98f735c407"
+"enforcement/hooks/stop_hook.py" = "sha256:95ee01ec189b4328daeafa1083d7ef1e5007878600b53145af07c3704748dbb1"
+"enforcement/hooks/primer.py" = "sha256:f29c8616469768ba6eeaa1ce7cdc3edd2c8df56e4be18f59b93a99c18e4e9196"
 "hooks/subagent_findings_check.py" = "sha256:b512fa239612e4a0c9a5c4e4d55c874bc30a487eae9e4e053c57f3716fce7b58"

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -43,8 +43,9 @@ class TestActiveRunMarker:
         (runs_dir / "run-1").mkdir(parents=True)
         (runs_dir / "run-3").mkdir(parents=True)
         (runs_dir / "run-2").mkdir(parents=True)
-        # Write a daemon.pid so it doesn't try to start daemon
-        (sahjhan_dir / "daemon.pid").write_text("99999999\n")
+        # Use our own PID — alive daemon triggers marker creation
+        (sahjhan_dir / "daemon.pid").write_text(f"{os.getpid()}\n")
+        (sahjhan_dir / "daemon-init-pid").write_text(f"{os.getpid()}\n")
 
         event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
         run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
@@ -67,147 +68,80 @@ class TestActiveRunMarker:
         assert (sahjhan_dir / "active-run").read_text().strip() == "run-5"
 
 
-class TestDaemonHealthCheck:
-    """Tests for daemon PID-based health checking."""
+class TestDaemonDeathTerminatesAudit:
+    """Daemon death with init PID tracking — audit terminated."""
 
-    def test_does_not_start_when_pid_alive(self, tmp_path):
-        """Daemon PID is alive → no restart attempt."""
-        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
-        sahjhan_dir.mkdir(parents=True)
-        (sahjhan_dir / "active-run").write_text("run-1\n")
-        # Use our own PID — guaranteed alive
-        (sahjhan_dir / "daemon.pid").write_text(f"{os.getpid()}\n")
-
-        event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
-        code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
-        assert code == 0
-        assert output.get("continue") is True
-        # Daemon.pid is not touched — hook exits before any restart attempt
-        assert (sahjhan_dir / "daemon.pid").read_text().strip() == str(os.getpid())
-
-    def test_starts_daemon_when_pid_dead(self, tmp_path):
-        """Daemon PID file exists but process is dead → attempt restart."""
-        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
-        sahjhan_dir.mkdir(parents=True)
-        (sahjhan_dir / "active-run").write_text("run-1\n")
-        # PID 99999999 is almost certainly not running
-        (sahjhan_dir / "daemon.pid").write_text("99999999\n")
-
-        event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
-        # This will attempt daemon start (which will fail since no real binary),
-        # but should still allow the tool call
-        code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
-        assert code == 0
-        assert output.get("continue") is True
-
-    def test_starts_daemon_when_no_pid_file(self, tmp_path):
-        """No daemon.pid → daemon not running → attempt start."""
-        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
-        sahjhan_dir.mkdir(parents=True)
-        (sahjhan_dir / "active-run").write_text("run-1\n")
-        # No daemon.pid file
-
-        event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
-        code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
-        assert code == 0
-        assert output.get("continue") is True
-
-    def test_allows_on_failure_when_no_fresh_enforcement(self, tmp_path):
-        """Daemon start fails + no fresh enforcement → allow (fail-open)."""
+    def test_blocks_when_init_pid_dead(self, tmp_path):
+        """Init PID dead → writes terminated marker, blocks."""
         sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
         sahjhan_dir.mkdir(parents=True)
         (sahjhan_dir / "active-run").write_text("run-1\n")
         (sahjhan_dir / "daemon.pid").write_text("99999999\n")
+        (sahjhan_dir / "daemon-init-pid").write_text("99999999\n")
 
         event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
         assert code == 0
-        assert output.get("continue") is True
-
-
-class TestDaemonLifecycleBlocksDuringActiveAudit:
-    """Issue #39: Dead daemon during active+fresh audit must block, not allow."""
-
-    def test_blocks_when_restart_fails_and_fresh(self, tmp_path):
-        """Daemon dead + restart fails + fresh enforcement → block."""
-        from datetime import datetime, timezone
-
-        from _protocol_cache import empty_cache, write_cache
-        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
-        sahjhan_dir.mkdir(parents=True)
-        (sahjhan_dir / "active-run").write_text("run-1\n")
-        (sahjhan_dir / "daemon.pid").write_text("99999999\n")  # dead PID
-
-        # Write a fresh cache so enforcement is active
-        cache = empty_cache()
-        cache["state"] = "fix_loop"
-        cache["last_sahjhan_cmd"] = datetime.now(timezone.utc).isoformat()  # noqa: UP017
-        write_cache(str(tmp_path), cache)
-
-        event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
-        code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
-        assert code == 0
-        # Should block, not allow
         assert output.get("continue") is False
         reason = output.get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
-        assert "ENFORCEMENT DEGRADED" in reason
+        assert "AUDIT TERMINATED" in reason
+        assert (sahjhan_dir / "terminated").exists()
 
-    def test_allows_when_restart_fails_and_stale(self, tmp_path):
-        """Daemon dead + restart fails + stale enforcement → allow (abandoned audit)."""
-        from _protocol_cache import empty_cache, write_cache
+    def test_allows_when_init_pid_alive(self, tmp_path):
+        """Init PID is alive → allow, no termination."""
         sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
         sahjhan_dir.mkdir(parents=True)
         (sahjhan_dir / "active-run").write_text("run-1\n")
-        (sahjhan_dir / "daemon.pid").write_text("99999999\n")  # dead PID
-
-        # Write a stale cache
-        cache = empty_cache()
-        cache["state"] = "fix_loop"
-        cache["last_sahjhan_cmd"] = "2025-01-01T00:00:00+00:00"  # very stale
-        write_cache(str(tmp_path), cache)
-
-        event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
-        code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
-        assert code == 0
-        assert output.get("continue") is True
-
-    def test_allows_when_no_cache_file(self, tmp_path):
-        """Daemon dead + no cache file → allow (no enforcement state to protect)."""
-        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
-        sahjhan_dir.mkdir(parents=True)
-        (sahjhan_dir / "active-run").write_text("run-1\n")
-        (sahjhan_dir / "daemon.pid").write_text("99999999\n")  # dead PID
-        # No cache file
-
-        event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
-        code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
-        assert code == 0
-        assert output.get("continue") is True
-
-
-class TestDaemonStartVerification:
-    """Issue #39 P3: Verify daemon is actually alive after start."""
-
-    def test_still_allows_when_daemon_alive(self, tmp_path):
-        """Daemon PID is alive → allow as before."""
-        from datetime import datetime, timezone
-
-        from _protocol_cache import empty_cache, write_cache
-        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
-        sahjhan_dir.mkdir(parents=True)
-        (sahjhan_dir / "active-run").write_text("run-1\n")
-        # Use our own PID — guaranteed alive
         (sahjhan_dir / "daemon.pid").write_text(f"{os.getpid()}\n")
-
-        cache = empty_cache()
-        cache["state"] = "fix_loop"
-        cache["last_sahjhan_cmd"] = datetime.now(timezone.utc).isoformat()  # noqa: UP017
-        write_cache(str(tmp_path), cache)
+        (sahjhan_dir / "daemon-init-pid").write_text(f"{os.getpid()}\n")
 
         event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
         assert code == 0
         assert output.get("continue") is True
+        assert not (sahjhan_dir / "terminated").exists()
+
+    def test_blocks_fast_when_terminated_marker_exists(self, tmp_path):
+        """Terminated marker already present → block immediately."""
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        (sahjhan_dir / "terminated").write_text("reason: daemon_pid_dead\n")
+
+        event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
+        code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
+        assert code == 0
+        assert output.get("continue") is False
+        reason = output.get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
+        assert "AUDIT TERMINATED" in reason
+
+    def test_allows_legacy_no_init_pid_file(self, tmp_path):
+        """No daemon-init-pid file → legacy audit, allow."""
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        (sahjhan_dir / "active-run").write_text("run-1\n")
+        (sahjhan_dir / "daemon.pid").write_text("99999999\n")
+
+        event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
+        code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
+        assert code == 0
+        assert output.get("continue") is True
+
+    def test_writes_terminated_cache_state(self, tmp_path):
+        """Terminated marker also updates enforcement-cache.json."""
+        import json
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        (sahjhan_dir / "active-run").write_text("run-1\n")
+        (sahjhan_dir / "daemon.pid").write_text("99999999\n")
+        (sahjhan_dir / "daemon-init-pid").write_text("99999999\n")
+
+        event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
+        run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
+
+        cache_path = sahjhan_dir / "enforcement-cache.json"
+        cache = json.loads(cache_path.read_text())
+        assert cache["state"] == "terminated"
+        assert cache["active"] is False
 
 
 class TestWriteTerminatedMarker:

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -208,3 +208,78 @@ class TestDaemonStartVerification:
         code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
         assert code == 0
         assert output.get("continue") is True
+
+
+class TestWriteTerminatedMarker:
+    """Tests for _write_terminated_marker shared helper."""
+
+    def test_creates_marker_file(self, tmp_path):
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        from _common import _write_terminated_marker
+        _write_terminated_marker(str(tmp_path), 12345, detected_by="_daemon_lifecycle")
+        marker = sahjhan_dir / "terminated"
+        assert marker.exists()
+        content = marker.read_text()
+        assert "reason: daemon_pid_dead" in content
+        assert "init_pid: 12345" in content
+        assert "detected_by: _daemon_lifecycle" in content
+        assert "detected_at:" in content
+
+    def test_updates_enforcement_cache(self, tmp_path):
+        import json
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        cache_path = sahjhan_dir / "enforcement-cache.json"
+        cache_path.write_text(json.dumps({"state": "fix_loop", "active": True}))
+        from _common import _write_terminated_marker
+        _write_terminated_marker(str(tmp_path), 12345)
+        cache = json.loads(cache_path.read_text())
+        assert cache["state"] == "terminated"
+        assert cache["active"] is False
+        assert cache["terminated_reason"] == "daemon_pid_dead"
+
+    def test_handles_missing_cache(self, tmp_path):
+        import json
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        from _common import _write_terminated_marker
+        _write_terminated_marker(str(tmp_path), 12345)
+        cache_path = sahjhan_dir / "enforcement-cache.json"
+        cache = json.loads(cache_path.read_text())
+        assert cache["state"] == "terminated"
+        assert cache["active"] is False
+
+    def test_handles_corrupt_cache(self, tmp_path):
+        import json
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        (sahjhan_dir / "enforcement-cache.json").write_text("NOT JSON{{{")
+        from _common import _write_terminated_marker
+        _write_terminated_marker(str(tmp_path), 12345)
+        cache = json.loads((sahjhan_dir / "enforcement-cache.json").read_text())
+        assert cache["state"] == "terminated"
+
+
+class TestReadInitPid:
+    """Tests for _read_init_pid shared helper."""
+
+    def test_reads_existing_pid(self, tmp_path):
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        (sahjhan_dir / "daemon-init-pid").write_text("72578\n")
+        from _common import _read_init_pid
+        assert _read_init_pid(str(tmp_path)) == 72578
+
+    def test_returns_none_when_missing(self, tmp_path):
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        from _common import _read_init_pid
+        assert _read_init_pid(str(tmp_path)) is None
+
+    def test_returns_none_on_corrupt_file(self, tmp_path):
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        (sahjhan_dir / "daemon-init-pid").write_text("not-a-number\n")
+        from _common import _read_init_pid
+        assert _read_init_pid(str(tmp_path)) is None

--- a/tests/test_primer.py
+++ b/tests/test_primer.py
@@ -1,0 +1,82 @@
+"""Tests for primer.py — UserPromptSubmit hook."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "enforcement", "hooks"))
+sys.path.insert(0, os.path.join(REPO_ROOT, "tests"))
+
+from _resolve import ensure_sahjhan  # noqa: E402
+
+from test_sahjhan_integration import run_enforcement_hook  # noqa: E402
+
+SAHJHAN = ensure_sahjhan()
+CONFIG_DIR = os.path.join(REPO_ROOT, "enforcement")
+
+pytestmark = pytest.mark.skipif(
+    SAHJHAN is None, reason="sahjhan binary not available"
+)
+
+
+def _init_sahjhan(tmp_path):
+    """Initialize sahjhan working directory so status commands succeed."""
+    subprocess.run(
+        [SAHJHAN, "--config-dir", CONFIG_DIR, "init"],
+        capture_output=True, text=True, timeout=5, cwd=str(tmp_path),
+        check=True,
+    )
+    ledger_path = str(tmp_path / "run-1.jsonl")
+    subprocess.run(
+        [SAHJHAN, "--config-dir", CONFIG_DIR, "ledger", "create",
+         "--name", "run-1", "--path", ledger_path],
+        capture_output=True, text=True, timeout=5, cwd=str(tmp_path),
+        check=True,
+    )
+
+
+class TestPrimerTerminatedAudit:
+    """Primer detects terminated audit and injects termination message."""
+
+    def test_injects_termination_when_marker_exists(self, tmp_path):
+        """Terminated marker present → inject termination message."""
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        (sahjhan_dir / "terminated").write_text("reason: daemon_pid_dead\n")
+        (sahjhan_dir / "active-run").write_text("run-1\n")
+
+        event = {"cwd": str(tmp_path)}
+        code, output, _ = run_enforcement_hook("primer.py", event, cwd=str(tmp_path))
+        assert code == 0
+        # Primer uses exit_warn, so continue=True, suppressOutput=False
+        assert output.get("continue") is True
+        context = output.get("additionalContext", "")
+        assert "AUDIT TERMINATED" in context
+
+    def test_no_restart_attempt_on_socket_failure(self, tmp_path):
+        """Socket failure does not attempt daemon restart."""
+        _init_sahjhan(tmp_path)
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        (sahjhan_dir / "active-run").write_text("run-1\n")
+        (sahjhan_dir / "daemon-init-pid").write_text("99999999\n")
+
+        # No daemon running — record_authed_event will fail
+        event = {"cwd": str(tmp_path)}
+        code, output, _ = run_enforcement_hook("primer.py", event, cwd=str(tmp_path))
+        assert code == 0
+        # Should write terminated marker since init PID is dead
+        assert (sahjhan_dir / "terminated").exists()
+
+
+class TestPrimerNoAudit:
+    """Primer exits clean when no audit is active."""
+
+    def test_allows_when_no_sahjhan_dir(self, tmp_path):
+        """No .sahjhan dir → no injection, silent allow."""
+        event = {"cwd": str(tmp_path)}
+        code, output, _ = run_enforcement_hook("primer.py", event, cwd=str(tmp_path))
+        assert code == 0

--- a/tests/test_sahjhan_integration.py
+++ b/tests/test_sahjhan_integration.py
@@ -1245,6 +1245,23 @@ class TestStopHook:
         )
 
 
+class TestStopHookTerminatedAudit:
+    """Stop hook allows stop when audit is terminated."""
+
+    def test_allows_stop_on_terminated_marker(self, tmp_path):
+        """Terminated marker present → allow stop."""
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        sahjhan_dir.mkdir(parents=True)
+        (sahjhan_dir / "terminated").write_text("reason: daemon_pid_dead\n")
+
+        event = {"cwd": str(tmp_path)}
+        code, output, _ = run_enforcement_hook("stop_hook.py", event, cwd=str(tmp_path))
+        assert code == 0
+        assert output.get("decision") != "block", (
+            f"Terminated audit should allow stop but got: {output}"
+        )
+
+
 # --- post_tool_hook.py (PostToolUse) ---
 
 

--- a/tests/test_sahjhan_integration.py
+++ b/tests/test_sahjhan_integration.py
@@ -692,12 +692,13 @@ class TestPrimer:
         assert code == 0, "primer should degrade gracefully on OSError"
         assert output.get("continue") is True
 
-    def test_restart_retry_on_daemon_failure(self):
-        """When context_reset fails, primer attempts daemon restart and retries.
+    def test_daemon_death_terminates_on_socket_failure(self):
+        """When context_reset fails and init PID is dead, primer writes terminated marker.
 
-        Uses a mock socket that rejects the first connection (simulating dead
-        daemon), then accepts after restart. The restart is simulated by the
-        mock binary's daemon-start command creating a flag file.
+        Uses a mock binary that returns valid status, but no daemon socket
+        exists — so record_authed_event fails with OSError. The primer then
+        checks daemon-init-pid, finds PID 99999999 is dead, and writes a
+        terminated marker. No daemon restart is attempted.
         """
         import shutil
         import tempfile
@@ -705,13 +706,11 @@ class TestPrimer:
         short_tmp = tempfile.mkdtemp(prefix="hz")
         tmp_path = Path(short_tmp)
         try:
-            self._run_restart_retry_test(tmp_path)
+            self._run_daemon_death_test(tmp_path)
         finally:
             shutil.rmtree(short_tmp, ignore_errors=True)
 
-    def _run_restart_retry_test(self, tmp_path):
-        import socket as socket_mod
-        import threading
+    def _run_daemon_death_test(self, tmp_path):
         from datetime import datetime, timezone
 
         sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
@@ -725,9 +724,12 @@ class TestPrimer:
         _cache["last_sahjhan_cmd"] = datetime.now(timezone.utc).isoformat()  # noqa: UP017
         write_cache(str(tmp_path), _cache)
 
+        # Dead init PID — this is how primer detects daemon death
+        (sahjhan_dir / "daemon-init-pid").write_text("99999999\n")
+        (sahjhan_dir / "active-run").write_text("run-1\n")
+
         # Track calls to the mock binary
         log_file = tmp_path / "cmd.log"
-        restart_flag = tmp_path / "daemon_restarted"
 
         _create_mock_binary(tmp_path, (
             'echo "$*" >> ' + str(log_file) + '\n'
@@ -736,66 +738,24 @@ class TestPrimer:
             '    echo "state: awaiting_clear (10 events, chain valid)"\n'
             '    exit 0\n'
             '    ;;\n'
-            '  *daemon*start*)\n'
-            '    touch ' + str(restart_flag) + '\n'
-            '    exit 0\n'
-            '    ;;\n'
             'esac\n'
             'exit 0'
         ))
 
-        # Mock daemon socket — first connection serves the sign request
-        # (The restart-retry logic means primer will attempt daemon start
-        # then retry record_authed_event. We set up the socket to serve
-        # the retry's sign request.)
-        sock_path = str(sahjhan_dir / "daemon.sock")
-        srv = socket_mod.socket(socket_mod.AF_UNIX, socket_mod.SOCK_STREAM)
-        srv.bind(sock_path)
-        srv.listen(1)
-        srv.settimeout(5)
-
-        attempt = {"count": 0}
-
-        def _serve():
-            import json as _json
-            try:
-                conn, _ = srv.accept()
-                attempt["count"] += 1
-                data = conn.makefile().readline()
-                req = _json.loads(data)
-                if attempt["count"] == 1:
-                    # First attempt: return error (simulates dead daemon)
-                    conn.sendall((_json.dumps({"ok": False, "message": "not ready"}) + "\n").encode())
-                    conn.close()
-                    # Accept the retry after restart
-                    conn2, _ = srv.accept()
-                    data = conn2.makefile().readline()
-                    req = _json.loads(data)
-                    if req.get("op") == "sign":
-                        conn2.sendall((_json.dumps({"ok": True, "proof": "deadbeef"}) + "\n").encode())
-                    conn2.close()
-                else:
-                    if req.get("op") == "sign":
-                        conn.sendall((_json.dumps({"ok": True, "proof": "deadbeef"}) + "\n").encode())
-                    conn.close()
-            except Exception:
-                pass
-
-        t = threading.Thread(target=_serve, daemon=True)
-        t.start()
-
+        # No daemon socket — record_authed_event will fail with OSError
         event = {"user_message": "continue", "cwd": str(tmp_path)}
         code, output, stderr = run_enforcement_hook(
             "primer.py", event, cwd=str(tmp_path), env=_mock_env(tmp_path)
         )
-        srv.close()
 
-        # Verify daemon start was attempted
-        assert restart_flag.exists(), "primer should have attempted daemon restart"
-
-        # Verify context_reset was recorded (retry succeeded)
-        logged = log_file.read_text()
-        assert "context_reset" in logged, "retry should have recorded context_reset"
+        # Verify terminated marker was written (no restart attempted)
+        assert (sahjhan_dir / "terminated").exists(), (
+            "primer should write terminated marker when init PID is dead"
+        )
+        context = output.get("additionalContext", "")
+        assert "AUDIT TERMINATED" in context, (
+            "primer should inject termination message"
+        )
 
 
 # --- BH-004 (run 28): hooks.json configuration validation ---


### PR DESCRIPTION
## Summary

- **Daemon death = audit terminal**: When the sahjhan daemon dies, the HMAC session key is lost and the ledger becomes permanently unwritable. Hooks now detect this via `daemon-init-pid` tracking and write a `terminated` marker, blocking all further tool use instead of silently restarting with a new (useless) key.
- **Sahjhan 0.10.0**: Upgraded binary with `--idle-timeout` flag support (jbrjake/sahjhan#24), reducing unnecessary daemon death during idle states like `awaiting_clear`.
- **Stop hook**: Allows `/stop` on terminated audits so users aren't trapped.

### Commits
- `feat(enforcement): add terminated marker and init-pid helpers`
- `feat(enforcement): daemon death terminates audit, never restarts`
- `feat(enforcement): primer detects daemon death, no restart`
- `feat(enforcement): stop hook allows stop on terminated audit`
- `feat(enforcement): upgrade sahjhan to 0.10.0`
- `fix(enforcement): fix Python 3.10 compat in _common.py`
- `fix(enforcement): fix doubled timezone suffix in terminated marker`

### Test plan
- [x] 1013 tests pass, 79% coverage
- [x] CI green on push
- [ ] Merge to main, verify release action creates tag + GitHub release

Ref: jbrjake/holtz#37, jbrjake/sahjhan#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)