### PR TITLE
chore: release v0.115.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.112.2",
+  "version": "0.113.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.113.0",
+  "version": "0.114.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.115.1",
+  "version": "0.115.2",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.115.2",
+  "version": "0.115.3",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.115.0",
+  "version": "0.115.1",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.115.3] - 2026-04-07
+
+_Changes since v0.112.2_
+
+### Added
+- **holtz:** add deferral procedures to step-10 fix loop
+- **enforcement:** add finding deferral to protocol and templates
+- **enforcement:** add reproduction evidence validation script
+
+### Fixed
+- **enforcement:** rename misleading stale-path test for accuracy
+- **enforcement:** don't kill daemon in awaiting_clear state
+- **enforcement:** use shell builtins for repro evidence gate
+- **enforcement:** background daemon start in phase-recon instructions
+
+### Documentation
+- add implementation plan for issue #43 stop hook daemon cleanup
+- add design spec for issue #43 stop hook daemon cleanup fix
+- add deferred finding protocol implementation plan
+- add deferred finding protocol design spec
+- update changelog for v0.112.2
+
+### Infrastructure
+- update test badge count to 1020
+- **enforcement:** add failing tests for issue #43 daemon cleanup gating
+- update .sahjhan-version marker to 0.10.0
+
 ## [0.112.2] - 2026-04-07
 
 _Changes since v0.112.1_

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/jbrjake/holtz/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/jbrjake/holtz/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)
-![1013 tests](https://img.shields.io/badge/tests-1013_total-brightgreen.svg)
+![1017 tests](https://img.shields.io/badge/tests-1017_total-brightgreen.svg)
 ![80% coverage](https://img.shields.io/badge/coverage-80%25-brightgreen.svg)
 
 **Adversarial TDD audit loop for Claude Code.** Dual auditors find bugs, write failing tests, fix them, and repeat until two consecutive passes find nothing new.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/jbrjake/holtz/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/jbrjake/holtz/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)
-![1017 tests](https://img.shields.io/badge/tests-1017_total-brightgreen.svg)
+![1020 tests](https://img.shields.io/badge/tests-1020_total-brightgreen.svg)
 ![80% coverage](https://img.shields.io/badge/coverage-80%25-brightgreen.svg)
 
 **Adversarial TDD audit loop for Claude Code.** Dual auditors find bugs, write failing tests, fix them, and repeat until two consecutive passes find nothing new.

--- a/docs/superpowers/plans/2026-04-07-deferred-finding-protocol.md
+++ b/docs/superpowers/plans/2026-04-07-deferred-finding-protocol.md
@@ -1,0 +1,690 @@
+# Deferred Finding Protocol — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add enforcement-level support for deferring punchlist findings via Sahjhan, with severity-based rules and evidence gates.
+
+**Architecture:** Three self-loop transitions (`defer_cant_reproduce`, `defer_low`, `defer_medium`) in the fix loop, each with appropriate gates. A new `finding_deferred` event records deferrals. Convergence gates updated to treat deferred findings like resolved ones. Templates updated to render DEFERRED status.
+
+**Tech Stack:** TOML (Sahjhan config), Tera (templates), Python (evidence script + tests)
+
+**Spec:** `docs/superpowers/specs/2026-04-07-deferred-finding-protocol-design.md`
+
+---
+
+### Task 1: Evidence Validation Script
+
+**Files:**
+- Create: `enforcement/scripts/check_repro_evidence.py`
+- Create: `tests/test_repro_evidence.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Tests for check_repro_evidence.py."""
+from __future__ import annotations
+
+import pytest
+
+from enforcement.scripts.check_repro_evidence import check_repro_evidence
+
+
+def test_investigation_file_exists(tmp_path):
+    """Investigation file present — evidence sufficient."""
+    inv = tmp_path / "investigations" / "BH-042.md"
+    inv.parent.mkdir(parents=True)
+    inv.write_text("## Reproduction Attempts\n\n- Ran test 100x, 0 failures\n")
+    assert check_repro_evidence("BH-042", str(tmp_path)) is True
+
+
+def test_no_investigation_file_fails(tmp_path):
+    """No investigation file and no evidence — fails."""
+    assert check_repro_evidence("BH-042", str(tmp_path)) is False
+
+
+def test_empty_investigation_file_fails(tmp_path):
+    """Empty investigation file is not evidence."""
+    inv = tmp_path / "investigations" / "BH-042.md"
+    inv.parent.mkdir(parents=True)
+    inv.write_text("")
+    assert check_repro_evidence("BH-042", str(tmp_path)) is False
+
+
+def test_invalid_finding_id_raises():
+    """Invalid finding ID format raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid finding ID"):
+        check_repro_evidence("BOGUS", "/tmp")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_repro_evidence.py -v`
+Expected: FAIL — `ModuleNotFoundError` or `ImportError` because `check_repro_evidence` doesn't exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+#!/usr/bin/env python3
+"""Check that a can't-reproduce deferral has sufficient evidence.
+
+Verifies that an investigation file exists at
+docs/holtz/investigations/{item_id}.md and is non-empty.
+
+Usage: python check_repro_evidence.py <finding_id> [--holtz-dir PATH]
+Exit 0 if evidence found, exit 1 otherwise.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+FINDING_ID_RE = re.compile(r"^B[HJ]-\d{3}$")
+
+
+def check_repro_evidence(finding_id: str, holtz_dir: str) -> bool:
+    """Return True if reproduction evidence exists for the finding.
+
+    Args:
+        finding_id: The punchlist item ID (e.g., BH-042).
+        holtz_dir: Path to the docs/holtz directory.
+    """
+    if not FINDING_ID_RE.match(finding_id):
+        raise ValueError(
+            f"Invalid finding ID '{finding_id}'. Expected format: BH-NNN or BJ-NNN"
+        )
+
+    investigation_path = os.path.join(
+        holtz_dir, "investigations", f"{finding_id}.md"
+    )
+
+    if not os.path.isfile(investigation_path):
+        return False
+
+    # File must be non-empty
+    return os.path.getsize(investigation_path) > 0
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(
+            "Usage: check_repro_evidence.py <finding_id> [--holtz-dir PATH]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    finding_id = sys.argv[1]
+    holtz_dir = "docs/holtz"
+    if "--holtz-dir" in sys.argv:
+        idx = sys.argv.index("--holtz-dir")
+        if idx + 1 < len(sys.argv):
+            holtz_dir = sys.argv[idx + 1]
+
+    try:
+        if check_repro_evidence(finding_id, holtz_dir):
+            print(f"PASS: Evidence found for {finding_id}")
+            sys.exit(0)
+        else:
+            print(
+                f"FAIL: No evidence for {finding_id}. "
+                f"Expected investigation file at {holtz_dir}/investigations/{finding_id}.md",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    except ValueError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_repro_evidence.py -v`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Run linters**
+
+Run: `ruff check enforcement/scripts/check_repro_evidence.py tests/test_repro_evidence.py`
+Expected: No violations.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add enforcement/scripts/check_repro_evidence.py tests/test_repro_evidence.py
+git commit -m "feat(enforcement): add reproduction evidence validation script
+
+Gate script for can't-reproduce deferrals. Checks that an investigation
+file exists at docs/holtz/investigations/{finding_id}.md and is non-empty.
+
+Ref: BH-042"
+```
+
+---
+
+### Task 2: Event Definition
+
+**Files:**
+- Modify: `enforcement/events.toml` (append after line 515)
+
+- [ ] **Step 1: Add the `finding_deferred` event definition**
+
+Append to `enforcement/events.toml` after the `_checkpoint` event:
+
+```toml
+[events.finding_deferred]
+description = "A finding was deferred"
+fields = [
+    { name = "project", type = "string" },
+    { name = "run", type = "string", pattern = "^\\d+$" },
+    { name = "auditor", type = "string", pattern = "^(holtz|justine)$" },
+    { name = "phase", type = "string", pattern = "^(recon|audit|merge|fix_loop|convergence|finalize)$" },
+    { name = "step", type = "string", pattern = "^\\d+$" },
+    { name = "id", type = "string", pattern = "^B[HJ]-\\d{3}$" },
+    { name = "reason", type = "string", pattern = "^(cant_reproduce|low_priority|medium_budget)$" },
+    { name = "evidence_path", type = "string", optional = true },
+]
+```
+
+- [ ] **Step 2: Verify TOML syntax**
+
+Run: `python -c "import tomllib; tomllib.load(open('enforcement/events.toml', 'rb')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add enforcement/events.toml
+git commit -m "feat(enforcement): add finding_deferred event definition
+
+Three deferral reasons: cant_reproduce (any severity, requires evidence),
+low_priority (LOW only), medium_budget (MEDIUM only, 50% cap)."
+```
+
+---
+
+### Task 3: Deferral Transitions
+
+**Files:**
+- Modify: `enforcement/transitions.toml` (insert after the `fix_commit` self-loop block, around line 75)
+
+- [ ] **Step 1: Add three deferral self-loop transitions**
+
+Insert after the `fix_commit` transition block (after line 75) and before the context reset section:
+
+```toml
+# ── Deferral: can't reproduce ──
+
+[[transitions]]
+from = "fix_loop"
+to = "fix_loop"
+command = "defer_cant_reproduce"
+args = ["item_id"]
+gates = [
+    { type = "query", sql = "SELECT count(*) >= 1 FROM events WHERE type='finding' AND id='{{item_id}}'", expect = "true", intent = "finding must exist" },
+    { type = "query", sql = "SELECT count(*) = 0 FROM events WHERE type IN ('finding_resolved', 'finding_deferred') AND id='{{item_id}}'", expect = "true", intent = "finding must not already be resolved or deferred" },
+    { type = "ledger_has_event_since", event = "fix_start", since = "last_transition", intent = "must have started working on this item" },
+    { type = "command_succeeds", cmd = "python enforcement/scripts/check_repro_evidence.py {{item_id}}", intent = "reproduction attempts must be documented in investigation file" },
+]
+
+# ── Deferral: LOW severity ──
+
+[[transitions]]
+from = "fix_loop"
+to = "fix_loop"
+command = "defer_low"
+args = ["item_id"]
+gates = [
+    { type = "query", sql = "SELECT count(*) >= 1 FROM events WHERE type='finding' AND id='{{item_id}}' AND severity='LOW'", expect = "true", intent = "finding must exist and be LOW severity" },
+    { type = "query", sql = "SELECT count(*) = 0 FROM events WHERE type IN ('finding_resolved', 'finding_deferred') AND id='{{item_id}}'", expect = "true", intent = "finding must not already be resolved or deferred" },
+]
+
+# ── Deferral: MEDIUM severity (budget-capped) ──
+
+[[transitions]]
+from = "fix_loop"
+to = "fix_loop"
+command = "defer_medium"
+args = ["item_id"]
+gates = [
+    { type = "query", sql = "SELECT count(*) >= 1 FROM events WHERE type='finding' AND id='{{item_id}}' AND severity='MEDIUM'", expect = "true", intent = "finding must exist and be MEDIUM severity" },
+    { type = "query", sql = "SELECT count(*) = 0 FROM events WHERE type IN ('finding_resolved', 'finding_deferred') AND id='{{item_id}}'", expect = "true", intent = "finding must not already be resolved or deferred" },
+    { type = "query", sql = "SELECT (SELECT count(*) FROM events WHERE type='finding_deferred' AND reason='medium_budget') < (SELECT count(*) FROM events WHERE type='finding' AND severity='MEDIUM') / 2", expect = "true", intent = "MEDIUM deferrals must not exceed 50% of total MEDIUM findings" },
+]
+```
+
+- [ ] **Step 2: Verify TOML syntax**
+
+Run: `python -c "import tomllib; tomllib.load(open('enforcement/transitions.toml', 'rb')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add enforcement/transitions.toml
+git commit -m "feat(enforcement): add deferral self-loop transitions
+
+Three fix_loop self-loops: defer_cant_reproduce (any severity, requires
+evidence + fix_start), defer_low (LOW only), defer_medium (MEDIUM only,
+50% budget cap enforced at deferral time)."
+```
+
+---
+
+### Task 4: Convergence Gate Updates
+
+**Files:**
+- Modify: `enforcement/transitions.toml` (lines 124 and 168)
+
+- [ ] **Step 1: Update the perspective completion gate (line 124)**
+
+Change the query in the `set complete perspective` transition from:
+
+```sql
+SELECT count(*) FROM events f WHERE f.type='finding' AND f.id NOT IN (SELECT r.id FROM events r WHERE r.type='finding_resolved')
+```
+
+To:
+
+```sql
+SELECT count(*) FROM events f WHERE f.type='finding' AND f.id NOT IN (SELECT r.id FROM events r WHERE r.type='finding_resolved') AND f.id NOT IN (SELECT d.id FROM events d WHERE d.type='finding_deferred')
+```
+
+Update the intent to: `"all findings must be resolved or deferred"`
+
+- [ ] **Step 2: Update the final sweep convergence gate (line 168)**
+
+Same change to the query in the `converge` transition. Same intent update.
+
+- [ ] **Step 3: Verify TOML syntax**
+
+Run: `python -c "import tomllib; tomllib.load(open('enforcement/transitions.toml', 'rb')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add enforcement/transitions.toml
+git commit -m "fix(enforcement): convergence gates accept deferred findings
+
+Both perspective completion and final sweep convergence gates now exclude
+deferred findings alongside resolved ones."
+```
+
+---
+
+### Task 5: Aliases
+
+**Files:**
+- Modify: `enforcement/protocol.toml` (in the `[aliases]` section, around line 60)
+
+- [ ] **Step 1: Add deferral aliases**
+
+Add the following lines to the `[aliases]` section in `enforcement/protocol.toml`:
+
+```toml
+"defer cant-reproduce" = "transition defer_cant_reproduce"
+"defer low" = "transition defer_low"
+"defer medium" = "transition defer_medium"
+```
+
+- [ ] **Step 2: Verify TOML syntax**
+
+Run: `python -c "import tomllib; tomllib.load(open('enforcement/protocol.toml', 'rb')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add enforcement/protocol.toml
+git commit -m "feat(enforcement): add defer aliases for sahjhan CLI
+
+sahjhan defer cant-reproduce BH-NNN, defer low BH-NNN, defer medium BH-NNN."
+```
+
+---
+
+### Task 6: Punchlist Template
+
+**Files:**
+- Modify: `enforcement/templates/punchlist.md.tera` (lines 11 and 22)
+
+- [ ] **Step 1: Add deferred ID set**
+
+After the `resolved_ids` line (line 11), add:
+
+```tera
+{% set deferred_ids = events | where_eq(attribute="event_type", value="finding_deferred") | unique_by(attribute="fields.id") | map(attribute="fields.id") -%}
+```
+
+- [ ] **Step 2: Update the status column**
+
+Replace the status cell on line 22:
+
+```tera
+| {% if resolved_ids is containing(e.fields.id) %}RESOLVED{% else %}OPEN{% endif %} |
+```
+
+With:
+
+```tera
+| {% if resolved_ids is containing(e.fields.id) %}RESOLVED{% elif deferred_ids is containing(e.fields.id) %}DEFERRED{% else %}OPEN{% endif %} |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add enforcement/templates/punchlist.md.tera
+git commit -m "feat(enforcement): render DEFERRED status in punchlist template"
+```
+
+---
+
+### Task 7: Status Template
+
+**Files:**
+- Modify: `enforcement/templates/status.md.tera` (lines 23-24)
+
+- [ ] **Step 1: Add deferred count and update findings line**
+
+After the `resolved_count` line (line 23), add:
+
+```tera
+{% set deferred_count = events | where_eq(attribute="event_type", value="finding_deferred") | unique_by(attribute="fields.id") | length -%}
+```
+
+Replace line 24:
+
+```tera
+**Open:** {{ finding_count - resolved_count }} | **Resolved:** {{ resolved_count }} | **Total:** {{ finding_count }}
+```
+
+With:
+
+```tera
+**Open:** {{ finding_count - resolved_count - deferred_count }} | **Resolved:** {{ resolved_count }} | **Deferred:** {{ deferred_count }} | **Total:** {{ finding_count }}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add enforcement/templates/status.md.tera
+git commit -m "feat(enforcement): add deferred count to status template"
+```
+
+---
+
+### Task 8: Summary Template
+
+**Files:**
+- Modify: `enforcement/templates/summary.md.tera` (lines 15-26, 34-44)
+
+- [ ] **Step 1: Add deferred set to the results section**
+
+After line 15 (`resolutions` set), add:
+
+```tera
+{% set deferrals = events | where_eq(attribute="event_type", value="finding_deferred") | unique_by(attribute="fields.id") -%}
+{% set deferred_count = deferrals | length -%}
+```
+
+- [ ] **Step 2: Update the Results table**
+
+Replace line 26:
+
+```tera
+| Open at convergence | {{ finding_count - resolved_count }} |
+```
+
+With:
+
+```tera
+| Resolved | {{ resolved_count }} |
+| Deferred | {{ deferred_count }} |
+| Open at convergence | {{ finding_count - resolved_count - deferred_count }} |
+```
+
+And remove the existing `| Resolved | {{ resolved_count }} |` line (line 25) since it's now in the block above.
+
+- [ ] **Step 3: Add deferred column to severity breakdown**
+
+After building `resolved_ids` (line 34), add:
+
+```tera
+{% set deferred_ids = deferrals | map(attribute="fields.id") -%}
+```
+
+Replace the severity table header (line 35):
+
+```tera
+| Severity | Found | Resolved |
+```
+
+With:
+
+```tera
+| Severity | Found | Resolved | Deferred |
+```
+
+In the severity loop body (lines 39-44), after the `sev_resolved` counter, add a `sev_deferred` counter:
+
+```tera
+{% set_global sev_deferred = 0 -%}
+{% for e in sev_findings -%}
+{% if deferred_ids is containing(e.fields.id) %}{% set_global sev_deferred = sev_deferred + 1 %}{% endif -%}
+{% endfor -%}
+```
+
+Update the row output from:
+
+```tera
+| {{ severity }} | {{ sev_findings | length }} | {{ sev_resolved }} |
+```
+
+To:
+
+```tera
+| {{ severity }} | {{ sev_findings | length }} | {{ sev_resolved }} | {{ sev_deferred }} |
+```
+
+- [ ] **Step 4: Add deferred column to perspective breakdown**
+
+Same pattern as severity. Replace the perspective table header (line 51):
+
+```tera
+| Perspective | Found | Resolved |
+```
+
+With:
+
+```tera
+| Perspective | Found | Resolved | Deferred |
+```
+
+In the perspective loop body (lines 55-57), add after `persp_resolved`:
+
+```tera
+{% set_global persp_deferred = 0 -%}
+{% for e in persp_findings -%}
+{% if deferred_ids is containing(e.fields.id) %}{% set_global persp_deferred = persp_deferred + 1 %}{% endif -%}
+{% endfor -%}
+```
+
+Update the row output from:
+
+```tera
+| {{ m.name }} | {{ persp_findings | length }} | {{ persp_resolved }} |
+```
+
+To:
+
+```tera
+| {{ m.name }} | {{ persp_findings | length }} | {{ persp_resolved }} | {{ persp_deferred }} |
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add enforcement/templates/summary.md.tera
+git commit -m "feat(enforcement): add deferred counts to summary template
+
+Results table, severity breakdown, and perspective breakdown all track
+deferred findings alongside resolved."
+```
+
+---
+
+### Task 9: Render Trigger
+
+**Files:**
+- Modify: `enforcement/renders.toml` (line 11)
+
+- [ ] **Step 1: Add `finding_deferred` to the punchlist render trigger**
+
+Replace line 11:
+
+```toml
+event_types = ["finding", "finding_resolved"]
+```
+
+With:
+
+```toml
+event_types = ["finding", "finding_resolved", "finding_deferred"]
+```
+
+- [ ] **Step 2: Verify TOML syntax**
+
+Run: `python -c "import tomllib; tomllib.load(open('enforcement/renders.toml', 'rb')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add enforcement/renders.toml
+git commit -m "feat(enforcement): trigger punchlist re-render on finding_deferred"
+```
+
+---
+
+### Task 10: Step-10 Procedure Updates
+
+**Files:**
+- Modify: `skills/holtz/references/step-10-fix-loop.md`
+
+- [ ] **Step 1: Update the triage flowchart**
+
+Replace the existing flowchart (lines 7-30) with:
+
+```dot
+digraph {
+  rankdir=TB
+  node [shape=box]
+  read [label="Re-read worklist\n(MERGED if exists,\notherwise PUNCHLIST)"]
+  triage [label="Triage item\nby category"]
+  fast [label="Fast Path\n(test→fix→commit)"]
+  investigate [label="Investigation Path\n(layers→confidence→fix)"]
+  cantrepro [label="Can't-Reproduce Path\n(widen→bisect→defer)"]
+  defer [label="Priority Deferral\n(LOW or MEDIUM budget)"]
+  harden [label="Per-Fix Hardening\n(edges+regression)"]
+  blast [label="Blast Radius Analysis\n(impact graph 2-hop)"]
+  next [label="Next item"]
+
+  read -> triage
+  triage -> fast [label="test/doc/design\nor deterministic bug"]
+  triage -> investigate [label="intermittent\nor theoretical bug"]
+  triage -> cantrepro [label="repro test\nunexpectedly passes"]
+  triage -> defer [label="LOW severity\nor MEDIUM with budget"]
+  fast -> harden
+  investigate -> harden
+  cantrepro -> harden [label="if reproduced"]
+  cantrepro -> next [label="sahjhan defer\ncant-reproduce"]
+  defer -> next [label="sahjhan defer\nlow/medium"]
+  harden -> blast
+  blast -> next
+}
+```
+
+- [ ] **Step 2: Update the can't-reproduce path (line 89)**
+
+Replace:
+
+```markdown
+If not reproducible after structured attempts: mark the item DEFERRED with evidence. Do not silently drop it.
+```
+
+With:
+
+```markdown
+If not reproducible after structured attempts:
+
+1. Ensure reproduction attempts are documented in `docs/holtz/investigations/{item_id}.md`
+2. Run: `sahjhan defer cant-reproduce {item_id}`
+3. Run: `sahjhan event finding_deferred --field id={item_id} --field reason=cant_reproduce --field evidence_path=docs/holtz/investigations/{item_id}.md`
+4. Update PUNCHLIST.md status to DEFERRED
+
+Do not silently drop the item.
+```
+
+- [ ] **Step 3: Add Priority Deferral section**
+
+After the Can't-Reproduce Path section, add a new section:
+
+```markdown
+## Priority Deferral
+
+For LOW and MEDIUM findings where the fix is legitimate but lower priority than the current audit scope. This is not a shortcut — attempt triage before deferring.
+
+**LOW severity:** All LOW findings may be deferred.
+
+```
+sahjhan defer low {item_id}
+sahjhan event finding_deferred --field id={item_id} --field reason=low_priority
+```
+
+**MEDIUM severity:** Up to half of MEDIUM findings may be deferred. The budget is enforced at deferral time — if the cap is reached, the transition is blocked.
+
+```
+sahjhan defer medium {item_id}
+sahjhan event finding_deferred --field id={item_id} --field reason=medium_budget
+```
+
+HIGH and CRITICAL findings are never deferrable via priority (only via can't-reproduce with evidence).
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/holtz/references/step-10-fix-loop.md
+git commit -m "feat(holtz): add deferral procedures to step-10 fix loop
+
+Triage flowchart updated with priority deferral path. Can't-reproduce
+path now references sahjhan commands. New Priority Deferral section
+documents LOW/MEDIUM deferral rules and budget cap."
+```
+
+---
+
+### Task 11: Full Test Suite Verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `python -m pytest --tb=short -q`
+Expected: All tests pass, no regressions.
+
+- [ ] **Step 2: Run linters**
+
+Run: `ruff check .`
+Expected: No violations.
+
+- [ ] **Step 3: Run type checker**
+
+Run: `mypy --explicit-package-bases skills/holtz/scripts/ hooks/ enforcement/hooks/`
+Expected: No errors.
+
+- [ ] **Step 4: Verify all TOML files parse**
+
+Run: `python -c "import tomllib, pathlib; [tomllib.load(open(f, 'rb')) for f in pathlib.Path('enforcement').glob('*.toml')]; print('All TOML files OK')"`
+Expected: `All TOML files OK`

--- a/docs/superpowers/plans/2026-04-07-issue-43-stop-hook-daemon-cleanup.md
+++ b/docs/superpowers/plans/2026-04-07-issue-43-stop-hook-daemon-cleanup.md
@@ -1,0 +1,294 @@
+# Issue #43: Stop Hook Daemon Cleanup Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent the stop hook from killing the sahjhan daemon when audit state is `awaiting_clear`, so audits can resume after `/clear`.
+
+**Architecture:** Add a second state set `_DAEMON_CLEANUP_STATES` that excludes `awaiting_clear`. Guard both daemon-cleanup call sites in `stop_hook.py` with this set. Add tests verifying the daemon is not killed in `awaiting_clear`.
+
+**Tech Stack:** Python, pytest
+
+**Spec:** `docs/superpowers/specs/2026-04-07-issue-43-stop-hook-daemon-cleanup-design.md`
+
+---
+
+### Task 1: Add tests for awaiting_clear daemon protection
+
+**Files:**
+- Modify: `tests/test_protocol_enforcement.py:1048-1061` (existing `test_allows_stop_in_awaiting_clear_state`)
+- Modify: `tests/test_protocol_enforcement.py:1064-1082` (existing `TestStopHookDaemonCleanup` class)
+
+These tests import `stop_hook` as a module and use `unittest.mock.patch` to verify `_try_stop_daemon` is/isn't called. The existing subprocess-based tests can't observe daemon cleanup because `ensure_sahjhan()` returns `None` in test (no binary). The unit tests complement the existing integration tests.
+
+- [ ] **Step 1: Write failing test — awaiting_clear must not trigger daemon cleanup**
+
+Add a new test class after `TestStopHookDaemonCleanup` (after line 1082) in `tests/test_protocol_enforcement.py`:
+
+```python
+class TestStopHookDaemonCleanupGating:
+    """Issue #43: awaiting_clear allows stop but must NOT kill daemon."""
+
+    def test_awaiting_clear_does_not_kill_daemon(self, tmp_path):
+        """awaiting_clear: stop allowed, daemon NOT killed (key needed for resume)."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch
+
+        from _protocol_cache import empty_cache, write_cache
+
+        cache = empty_cache()
+        cache["state"] = "awaiting_clear"
+        cache["last_sahjhan_cmd"] = datetime.now(timezone.utc).isoformat()  # noqa: UP017
+        write_cache(str(tmp_path), cache)
+
+        # Patch _try_stop_daemon at module level to track calls
+        import stop_hook
+        with patch.object(stop_hook, "_try_stop_daemon") as mock_stop:
+            event = {"cwd": str(tmp_path)}
+            code, output, _ = run_enforcement_hook("stop_hook.py", event)
+
+        assert code == 0
+        assert output == {}  # allow
+        mock_stop.assert_not_called()
+
+    def test_idle_still_kills_daemon(self, tmp_path):
+        """idle: stop allowed AND daemon killed (no audit to resume)."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch
+
+        from _protocol_cache import empty_cache, write_cache
+
+        cache = empty_cache()
+        cache["state"] = "idle"
+        cache["last_sahjhan_cmd"] = datetime.now(timezone.utc).isoformat()  # noqa: UP017
+        write_cache(str(tmp_path), cache)
+
+        import stop_hook
+        with patch.object(stop_hook, "_try_stop_daemon") as mock_stop:
+            event = {"cwd": str(tmp_path)}
+            code, output, _ = run_enforcement_hook("stop_hook.py", event)
+
+        assert code == 0
+        assert output == {}  # allow
+        mock_stop.assert_called_once()
+
+    def test_stale_awaiting_clear_does_not_kill_daemon(self, tmp_path):
+        """Stale awaiting_clear: warn but do NOT kill daemon."""
+        from unittest.mock import patch
+
+        from _protocol_cache import empty_cache, write_cache
+
+        cache = empty_cache()
+        cache["state"] = "awaiting_clear"
+        cache["last_sahjhan_cmd"] = "2025-01-01T00:00:00+00:00"  # very stale
+        write_cache(str(tmp_path), cache)
+
+        import stop_hook
+        with patch.object(stop_hook, "_try_stop_daemon") as mock_stop:
+            event = {"cwd": str(tmp_path)}
+            code, output, _ = run_enforcement_hook("stop_hook.py", event)
+
+        assert code == 0
+        # awaiting_clear is in _STOP_ALLOWED_STATES, so it hits that branch
+        # before the staleness check. It should allow stop without killing daemon.
+        mock_stop.assert_not_called()
+```
+
+**Note on mock approach:** `run_enforcement_hook` runs the hook as a subprocess, so `patch.object` on the imported module won't intercept the subprocess call. These tests will need to call `stop_hook.main()` directly instead. Revising:
+
+```python
+class TestStopHookDaemonCleanupGating:
+    """Issue #43: awaiting_clear allows stop but must NOT kill daemon."""
+
+    def test_awaiting_clear_does_not_kill_daemon(self, tmp_path):
+        """awaiting_clear: stop allowed, daemon NOT killed (key needed for resume)."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch
+
+        import pytest
+        from _protocol_cache import empty_cache, write_cache
+
+        cache = empty_cache()
+        cache["state"] = "awaiting_clear"
+        cache["last_sahjhan_cmd"] = datetime.now(timezone.utc).isoformat()  # noqa: UP017
+        write_cache(str(tmp_path), cache)
+
+        import stop_hook
+        with (
+            patch.object(stop_hook, "_try_stop_daemon") as mock_stop,
+            patch.object(stop_hook, "read_event", return_value={"cwd": str(tmp_path)}),
+            patch.object(stop_hook, "_has_active_audit", return_value=True),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                stop_hook.main()
+            assert exc_info.value.code == 0
+        mock_stop.assert_not_called()
+
+    def test_idle_still_kills_daemon(self, tmp_path):
+        """idle: stop allowed AND daemon killed (no audit to resume)."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch
+
+        import pytest
+        from _protocol_cache import empty_cache, write_cache
+
+        cache = empty_cache()
+        cache["state"] = "idle"
+        cache["last_sahjhan_cmd"] = datetime.now(timezone.utc).isoformat()  # noqa: UP017
+        write_cache(str(tmp_path), cache)
+
+        import stop_hook
+        with (
+            patch.object(stop_hook, "_try_stop_daemon") as mock_stop,
+            patch.object(stop_hook, "read_event", return_value={"cwd": str(tmp_path)}),
+            patch.object(stop_hook, "_has_active_audit", return_value=True),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                stop_hook.main()
+            assert exc_info.value.code == 0
+        mock_stop.assert_called_once()
+
+    def test_stale_awaiting_clear_does_not_kill_daemon(self, tmp_path):
+        """Stale awaiting_clear: still allows stop, does NOT kill daemon."""
+        from unittest.mock import patch
+
+        import pytest
+        from _protocol_cache import empty_cache, write_cache
+
+        cache = empty_cache()
+        cache["state"] = "awaiting_clear"
+        cache["last_sahjhan_cmd"] = "2025-01-01T00:00:00+00:00"  # very stale
+        write_cache(str(tmp_path), cache)
+
+        import stop_hook
+        with (
+            patch.object(stop_hook, "_try_stop_daemon") as mock_stop,
+            patch.object(stop_hook, "read_event", return_value={"cwd": str(tmp_path)}),
+            patch.object(stop_hook, "_has_active_audit", return_value=True),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                stop_hook.main()
+            assert exc_info.value.code == 0
+        # awaiting_clear is in _STOP_ALLOWED_STATES — hits that path before staleness
+        mock_stop.assert_not_called()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest tests/test_protocol_enforcement.py::TestStopHookDaemonCleanupGating -v`
+
+Expected: `test_awaiting_clear_does_not_kill_daemon` FAILS (mock IS called because current code calls `_try_stop_daemon` for all allowed states). `test_idle_still_kills_daemon` PASSES. `test_stale_awaiting_clear_does_not_kill_daemon` FAILS (same reason as first).
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/test_protocol_enforcement.py
+git commit -m "test(enforcement): add failing tests for issue #43 daemon cleanup gating"
+```
+
+---
+
+### Task 2: Implement the fix in stop_hook.py
+
+**Files:**
+- Modify: `enforcement/hooks/stop_hook.py:34` (add `_DAEMON_CLEANUP_STATES`)
+- Modify: `enforcement/hooks/stop_hook.py:86-88` (guard allowed-states path)
+- Modify: `enforcement/hooks/stop_hook.py:91-97` (guard stale-enforcement path)
+
+- [ ] **Step 1: Add `_DAEMON_CLEANUP_STATES` and comment**
+
+In `enforcement/hooks/stop_hook.py`, replace line 34:
+
+```python
+_STOP_ALLOWED_STATES = {"idle", "finalized", "awaiting_clear", ""}
+```
+
+With:
+
+```python
+# Two sets because "allowed to stop" ≠ "safe to kill daemon".
+# awaiting_clear allows stop (the turn is done) but the daemon must
+# survive — it holds the HMAC session key for the resuming session.
+# When adding states, decide: does the audit resume after this? If yes,
+# put it in _STOP_ALLOWED only. If the audit is over, put it in both.
+_STOP_ALLOWED_STATES = {"idle", "finalized", "awaiting_clear", ""}
+_DAEMON_CLEANUP_STATES = {"idle", "finalized", ""}
+```
+
+- [ ] **Step 2: Guard the allowed-states daemon cleanup (lines 86-88)**
+
+Replace:
+
+```python
+    if current_state in _STOP_ALLOWED_STATES:
+        _try_stop_daemon(cwd)
+        exit_stop_allow()
+```
+
+With:
+
+```python
+    if current_state in _STOP_ALLOWED_STATES:
+        if current_state in _DAEMON_CLEANUP_STATES:
+            _try_stop_daemon(cwd)
+        exit_stop_allow()
+```
+
+- [ ] **Step 3: Guard the stale-enforcement daemon cleanup (lines 91-92)**
+
+Replace:
+
+```python
+    if not is_enforcement_fresh(cache):
+        _try_stop_daemon(cwd)
+        exit_stop_warn(
+```
+
+With:
+
+```python
+    if not is_enforcement_fresh(cache):
+        if current_state in _DAEMON_CLEANUP_STATES:
+            _try_stop_daemon(cwd)
+        exit_stop_warn(
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `python -m pytest tests/test_protocol_enforcement.py -v`
+
+Expected: ALL pass, including the new `TestStopHookDaemonCleanupGating` tests.
+
+- [ ] **Step 5: Run linter and type checker**
+
+Run: `ruff check . && mypy --explicit-package-bases skills/holtz/scripts/ hooks/ enforcement/hooks/`
+
+Expected: Clean.
+
+- [ ] **Step 6: Commit the fix**
+
+```bash
+git add enforcement/hooks/stop_hook.py
+git commit -m "fix(enforcement): don't kill daemon in awaiting_clear state
+
+Closes #43. The stop hook conflated 'allowed to stop the turn' with
+'safe to kill the daemon'. awaiting_clear needs the daemon alive for
+the resuming session after /clear."
+```
+
+---
+
+### Task 3: Verify existing tests still pass
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `python -m pytest -v`
+
+Expected: All tests pass. No regressions.
+
+- [ ] **Step 2: Run linter and type checker**
+
+Run: `ruff check . && mypy --explicit-package-bases skills/holtz/scripts/ hooks/ enforcement/hooks/`
+
+Expected: Clean.

--- a/docs/superpowers/specs/2026-04-07-deferred-finding-protocol-design.md
+++ b/docs/superpowers/specs/2026-04-07-deferred-finding-protocol-design.md
@@ -1,0 +1,208 @@
+# Deferred Finding Protocol — Design Spec
+
+**Date:** 2026-04-07
+**Status:** Draft
+**Problem:** The punchlist format defines DEFERRED as a valid status, but the Sahjhan enforcement protocol has no mechanism to reach it. No `finding_deferred` event, no deferral transitions, and convergence gates treat unresolved findings identically to open ones — making deferral impossible within the protocol.
+
+## Constraints
+
+- Holtz-initiated only. No user deferrals.
+- Three deferral reasons, each with distinct rules:
+  - **cant_reproduce** — any severity, exempt from count limits, requires documented reproduction evidence
+  - **low_priority** — LOW severity only, no count limits
+  - **medium_budget** — MEDIUM severity only, capped at 50% of total MEDIUM findings
+- HIGH and CRITICAL findings are never deferrable except via cant_reproduce.
+- MEDIUM budget enforced at deferral time (not deferred at convergence).
+- Deferred findings do not block lens completion or convergence.
+
+## 1. Event Definition
+
+New event in `enforcement/events.toml`:
+
+```toml
+[events.finding_deferred]
+description = "A finding was deferred"
+fields = [
+    { name = "project", type = "string" },
+    { name = "run", type = "string", pattern = "^\\d+$" },
+    { name = "auditor", type = "string", pattern = "^(holtz|justine)$" },
+    { name = "phase", type = "string", pattern = "^(recon|audit|merge|fix_loop|convergence|finalize)$" },
+    { name = "step", type = "string", pattern = "^\\d+$" },
+    { name = "id", type = "string", pattern = "^B[HJ]-\\d{3}$" },
+    { name = "reason", type = "string", pattern = "^(cant_reproduce|low_priority|medium_budget)$" },
+    { name = "evidence_path", type = "string", optional = true },
+]
+```
+
+Three reasons map to three deferral tracks. `evidence_path` is optional on the event itself; the transition gate for cant_reproduce enforces evidence exists.
+
+## 2. Transitions
+
+Three `fix_loop -> fix_loop` self-loop transitions in `enforcement/transitions.toml`, one per reason. Separate transitions keep each gate set simple — no conditional SQL.
+
+### 2a. Can't Reproduce
+
+```toml
+[[transitions]]
+from = "fix_loop"
+to = "fix_loop"
+command = "defer_cant_reproduce"
+args = ["item_id"]
+gates = [
+    { type = "query", sql = "SELECT count(*) >= 1 FROM events WHERE type='finding' AND id='{{item_id}}'", expect = "true", intent = "finding must exist" },
+    { type = "query", sql = "SELECT count(*) = 0 FROM events WHERE type IN ('finding_resolved', 'finding_deferred') AND id='{{item_id}}'", expect = "true", intent = "finding must not already be resolved or deferred" },
+    { type = "ledger_has_event_since", event = "fix_start", since = "last_transition", intent = "must have started working on this item" },
+    { type = "command_succeeds", cmd = "python enforcement/scripts/check_repro_evidence.py {{item_id}}", intent = "reproduction attempts must be documented in investigation file or punchlist evidence" },
+]
+```
+
+Requires a `fix_start` event (Holtz must have actually attempted the item) and a script check for reproduction evidence.
+
+### 2b. LOW Severity
+
+```toml
+[[transitions]]
+from = "fix_loop"
+to = "fix_loop"
+command = "defer_low"
+args = ["item_id"]
+gates = [
+    { type = "query", sql = "SELECT count(*) >= 1 FROM events WHERE type='finding' AND id='{{item_id}}' AND severity='LOW'", expect = "true", intent = "finding must exist and be LOW severity" },
+    { type = "query", sql = "SELECT count(*) = 0 FROM events WHERE type IN ('finding_resolved', 'finding_deferred') AND id='{{item_id}}'", expect = "true", intent = "finding must not already be resolved or deferred" },
+]
+```
+
+Minimal gates — just existence and severity.
+
+### 2c. MEDIUM Severity (Budget-Capped)
+
+```toml
+[[transitions]]
+from = "fix_loop"
+to = "fix_loop"
+command = "defer_medium"
+args = ["item_id"]
+gates = [
+    { type = "query", sql = "SELECT count(*) >= 1 FROM events WHERE type='finding' AND id='{{item_id}}' AND severity='MEDIUM'", expect = "true", intent = "finding must exist and be MEDIUM severity" },
+    { type = "query", sql = "SELECT count(*) = 0 FROM events WHERE type IN ('finding_resolved', 'finding_deferred') AND id='{{item_id}}'", expect = "true", intent = "finding must not already be resolved or deferred" },
+    { type = "query", sql = "SELECT (SELECT count(*) FROM events WHERE type='finding_deferred' AND reason='medium_budget') < (SELECT count(*) FROM events WHERE type='finding' AND severity='MEDIUM') / 2", expect = "true", intent = "MEDIUM deferrals must not exceed 50% of total MEDIUM findings" },
+]
+```
+
+Budget query uses integer division: 3 MEDIUM findings = 1 deferral max, 5 = 2 max, etc. Enforced at deferral time.
+
+## 3. Aliases
+
+New aliases in `enforcement/protocol.toml`:
+
+```toml
+"defer cant-reproduce" = "transition defer_cant_reproduce"
+"defer low" = "transition defer_low"
+"defer medium" = "transition defer_medium"
+```
+
+Usage: `sahjhan defer cant-reproduce BH-042`, `sahjhan defer low BH-015`, etc.
+
+## 4. Convergence Gate Updates
+
+Two queries in `enforcement/transitions.toml` (lines 124 and 168) that currently require all findings resolved need to also exclude deferred findings:
+
+```sql
+-- Before:
+SELECT count(*) FROM events f WHERE f.type='finding'
+  AND f.id NOT IN (SELECT r.id FROM events r WHERE r.type='finding_resolved')
+
+-- After:
+SELECT count(*) FROM events f WHERE f.type='finding'
+  AND f.id NOT IN (SELECT r.id FROM events r WHERE r.type='finding_resolved')
+  AND f.id NOT IN (SELECT d.id FROM events d WHERE d.type='finding_deferred')
+```
+
+Updated intent: "all findings must be resolved or deferred."
+
+Both the perspective completion gate (line 124) and the final sweep convergence gate (line 168) get this change.
+
+## 5. Template Updates
+
+### punchlist.md.tera
+
+Add deferred ID set:
+
+```tera
+{% set deferred_ids = events | where_eq(attribute="event_type", value="finding_deferred")
+   | unique_by(attribute="fields.id") | map(attribute="fields.id") -%}
+```
+
+Three-way status column:
+
+```tera
+{% if resolved_ids is containing(e.fields.id) %}RESOLVED{% elif deferred_ids is containing(e.fields.id) %}DEFERRED{% else %}OPEN{% endif %}
+```
+
+### status.md.tera
+
+Add deferred count:
+
+```tera
+{% set deferred_count = events | where_eq(attribute="event_type", value="finding_deferred")
+   | unique_by(attribute="fields.id") | length -%}
+**Open:** {{ finding_count - resolved_count - deferred_count }} | **Resolved:** {{ resolved_count }} | **Deferred:** {{ deferred_count }} | **Total:** {{ finding_count }}
+```
+
+### summary.md.tera
+
+Same pattern — add deferred to severity breakdown table.
+
+### renders.toml
+
+Add `finding_deferred` to the punchlist render trigger:
+
+```toml
+event_types = ["finding", "finding_resolved", "finding_deferred"]
+```
+
+## 6. Evidence Script
+
+New script: `enforcement/scripts/check_repro_evidence.py`
+
+~30 lines. Takes a finding ID as argument. Checks:
+1. Investigation file exists at `docs/holtz/investigations/{item_id}.md`
+2. OR the ledger contains events showing structured reproduction attempts (multiple `fix_start` events for the same item, bash commands with loop/bisect patterns)
+
+Exits 0 if evidence found, exits 1 with message explaining what's missing. Follows the pattern of existing scripts `check_severity_change.py` and `check_sweep_evidence.py`.
+
+## 7. Procedure Updates
+
+### step-10-fix-loop.md
+
+Update the can't-reproduce path (line 89) to reference Sahjhan commands:
+
+```markdown
+If not reproducible after structured attempts:
+1. Ensure reproduction attempts are documented in the investigation file
+2. Run: `sahjhan defer cant-reproduce BH-NNN`
+3. Run: `sahjhan event finding_deferred --field id=BH-NNN --field reason=cant_reproduce --field evidence_path=docs/holtz/investigations/BH-NNN.md`
+```
+
+Add a new "Priority Deferral" section explaining when LOW/MEDIUM deferrals are appropriate — after triage, not as a first resort.
+
+Update the triage flowchart to add a deferral edge from triage for LOW items and budget-available MEDIUM items.
+
+## 8. No Changes Needed
+
+- `convergence_check.py` — already counts DEFERRED status
+- `validate_punchlist.py` — already validates DEFERRED items (checks for evidence on deferred bug items)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `enforcement/events.toml` | Add `finding_deferred` event |
+| `enforcement/transitions.toml` | Add 3 self-loop transitions + update 2 convergence gates |
+| `enforcement/protocol.toml` | Add 3 defer aliases |
+| `enforcement/renders.toml` | Add `finding_deferred` to punchlist trigger |
+| `enforcement/templates/punchlist.md.tera` | Three-way status column |
+| `enforcement/templates/status.md.tera` | Add deferred count |
+| `enforcement/templates/summary.md.tera` | Add deferred to severity breakdown |
+| `enforcement/scripts/check_repro_evidence.py` | New evidence validation script |
+| `skills/holtz/references/step-10-fix-loop.md` | Deferral procedures + flowchart update |

--- a/docs/superpowers/specs/2026-04-07-issue-43-stop-hook-daemon-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-07-issue-43-stop-hook-daemon-cleanup-design.md
@@ -1,0 +1,69 @@
+# Issue #43: Stop Hook Kills Daemon in awaiting_clear State
+
+## Problem
+
+The stop hook (`enforcement/hooks/stop_hook.py`) uses a single set `_STOP_ALLOWED_STATES` to control both "can the assistant stop its turn?" and "should we kill the daemon?" The `awaiting_clear` state is in this set, so the daemon gets killed at the end of the turn that transitions to `awaiting_clear` — before the user even has a chance to `/clear`. Since the daemon holds the HMAC session key exclusively in memory, this makes the audit unresumable.
+
+Every audit that reaches `awaiting_clear` via `iteration_boundary` is bricked by this.
+
+## Root Cause
+
+`_STOP_ALLOWED_STATES` on line 34 conflates two concerns:
+
+```python
+_STOP_ALLOWED_STATES = {"idle", "finalized", "awaiting_clear", ""}
+```
+
+Both the allowed-states path (line 86-88) and the stale-enforcement fallback (line 91-92) call `_try_stop_daemon` without distinguishing whether the daemon should survive.
+
+## Design
+
+### Two state sets
+
+Introduce `_DAEMON_CLEANUP_STATES` that excludes `awaiting_clear`. Add a comment explaining why both sets exist and how to decide which set a new state belongs in.
+
+```python
+# Two sets because "allowed to stop" ≠ "safe to kill daemon".
+# awaiting_clear allows stop (the turn is done) but the daemon must
+# survive — it holds the HMAC session key for the resuming session.
+# When adding states, decide: does the audit resume after this? If yes,
+# put it in _STOP_ALLOWED only. If the audit is over, put it in both.
+_STOP_ALLOWED_STATES = {"idle", "finalized", "awaiting_clear", ""}
+_DAEMON_CLEANUP_STATES = {"idle", "finalized", ""}
+```
+
+### Call site changes
+
+Two call sites need updating:
+
+1. **Allowed-states path (line 86-88):** Gate `_try_stop_daemon` on `_DAEMON_CLEANUP_STATES`.
+2. **Stale-enforcement fallback (line 91-97):** Same gate. A stale `awaiting_clear` audit still has a live daemon that should not be killed by the staleness heuristic — the user may return and `/clear`.
+
+```python
+if current_state in _STOP_ALLOWED_STATES:
+    if current_state in _DAEMON_CLEANUP_STATES:
+        _try_stop_daemon(cwd)
+    exit_stop_allow()
+
+if not is_enforcement_fresh(cache):
+    if current_state in _DAEMON_CLEANUP_STATES:
+        _try_stop_daemon(cwd)
+    exit_stop_warn(...)
+```
+
+### Files changed
+
+- `enforcement/hooks/stop_hook.py` — add `_DAEMON_CLEANUP_STATES`, guard both call sites
+- `tests/test_protocol_enforcement.py` — add test verifying `awaiting_clear` does not trigger daemon cleanup
+
+### Testing
+
+- Existing `test_allows_stop_in_awaiting_clear_state` already verifies stop is allowed (exit code 0). Extend or add a companion test that mocks `_try_stop_daemon` and asserts it is NOT called when state is `awaiting_clear`.
+- Add a test for the stale-enforcement path with `awaiting_clear` — should warn but not kill daemon.
+- Verify existing tests for `idle`, `finalized`, and active states still pass (daemon cleanup should still happen for those).
+
+### Out of scope
+
+- The `terminated` path (line 68-70) is correct — it always kills the daemon because the audit is already over.
+- `protocol_tracker.py` only kills on `finalized`, which is correct.
+- No changes to the state machine or transitions.

--- a/enforcement/events.toml
+++ b/enforcement/events.toml
@@ -513,3 +513,16 @@ fields = [
     { name = "auditor", type = "string", pattern = "^(holtz|justine)$" },
     { name = "note", type = "string", optional = true },
 ]
+
+[events.finding_deferred]
+description = "A finding was deferred"
+fields = [
+    { name = "project", type = "string" },
+    { name = "run", type = "string", pattern = "^\\d+$" },
+    { name = "auditor", type = "string", pattern = "^(holtz|justine)$" },
+    { name = "phase", type = "string", pattern = "^(recon|audit|merge|fix_loop|convergence|finalize)$" },
+    { name = "step", type = "string", pattern = "^\\d+$" },
+    { name = "id", type = "string", pattern = "^B[HJ]-\\d{3}$" },
+    { name = "reason", type = "string", pattern = "^(cant_reproduce|low_priority|medium_budget)$" },
+    { name = "evidence_path", type = "string", optional = true },
+]

--- a/enforcement/hooks/stop_hook.py
+++ b/enforcement/hooks/stop_hook.py
@@ -31,7 +31,13 @@ from _common import (  # noqa: E402
     resolve_config_dir,
 )
 
+# Two sets because "allowed to stop" ≠ "safe to kill daemon".
+# awaiting_clear allows stop (the turn is done) but the daemon must
+# survive — it holds the HMAC session key for the resuming session.
+# When adding states, decide: does the audit resume after this? If yes,
+# put it in _STOP_ALLOWED only. If the audit is over, put it in both.
 _STOP_ALLOWED_STATES = {"idle", "finalized", "awaiting_clear", ""}
+_DAEMON_CLEANUP_STATES = {"idle", "finalized", ""}
 
 
 def _try_stop_daemon(cwd: str) -> None:
@@ -84,12 +90,14 @@ def main() -> None:
 
     # Terminal or idle — allow stop
     if current_state in _STOP_ALLOWED_STATES:
-        _try_stop_daemon(cwd)
+        if current_state in _DAEMON_CLEANUP_STATES:
+            _try_stop_daemon(cwd)
         exit_stop_allow()
 
     # Non-terminal state: check freshness
     if not is_enforcement_fresh(cache):
-        _try_stop_daemon(cwd)
+        if current_state in _DAEMON_CLEANUP_STATES:
+            _try_stop_daemon(cwd)
         exit_stop_warn(
             f"Stale Holtz audit detected (state: '{current_state}'). "
             "No recent sahjhan activity — this appears to be an abandoned audit. "

--- a/enforcement/protocol.toml
+++ b/enforcement/protocol.toml
@@ -57,4 +57,7 @@ path = "docs/holtz/project.jsonl"
 "test finding" = "event test_audit_finding"
 "code finding" = "event code_audit_finding"
 "graph delta" = "event graph_delta"
+"defer cant-reproduce" = "transition defer_cant_reproduce"
+"defer low" = "transition defer_low"
+"defer medium" = "transition defer_medium"
 

--- a/enforcement/renders.toml
+++ b/enforcement/renders.toml
@@ -8,7 +8,7 @@ ledger_template = "run"
 target = "PUNCHLIST.md"
 template = "templates/punchlist.md.tera"
 trigger = "on_event"
-event_types = ["finding", "finding_resolved"]
+event_types = ["finding", "finding_resolved", "finding_deferred"]
 ledger_template = "run"
 
 [[renders]]

--- a/enforcement/scripts/check_repro_evidence.py
+++ b/enforcement/scripts/check_repro_evidence.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Check that a can't-reproduce deferral has sufficient evidence.
+
+Verifies that an investigation file exists at
+docs/holtz/investigations/{item_id}.md and is non-empty.
+
+Usage: python check_repro_evidence.py <finding_id> [--holtz-dir PATH]
+Exit 0 if evidence found, exit 1 otherwise.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+FINDING_ID_RE = re.compile(r"^B[HJ]-\d{3}$")
+
+
+def check_repro_evidence(finding_id: str, holtz_dir: str) -> bool:
+    """Return True if reproduction evidence exists for the finding.
+
+    Args:
+        finding_id: The punchlist item ID (e.g., BH-042).
+        holtz_dir: Path to the docs/holtz directory.
+    """
+    if not FINDING_ID_RE.match(finding_id):
+        raise ValueError(
+            f"Invalid finding ID '{finding_id}'. Expected format: BH-NNN or BJ-NNN"
+        )
+
+    investigation_path = os.path.join(
+        holtz_dir, "investigations", f"{finding_id}.md"
+    )
+
+    if not os.path.isfile(investigation_path):
+        return False
+
+    # File must be non-empty
+    return os.path.getsize(investigation_path) > 0
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(
+            "Usage: check_repro_evidence.py <finding_id> [--holtz-dir PATH]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    finding_id = sys.argv[1]
+    holtz_dir = "docs/holtz"
+    if "--holtz-dir" in sys.argv:
+        idx = sys.argv.index("--holtz-dir")
+        if idx + 1 < len(sys.argv):
+            holtz_dir = sys.argv[idx + 1]
+
+    try:
+        if check_repro_evidence(finding_id, holtz_dir):
+            print(f"PASS: Evidence found for {finding_id}")
+            sys.exit(0)
+        else:
+            print(
+                f"FAIL: No evidence for {finding_id}. "
+                f"Expected investigation file at {holtz_dir}/investigations/{finding_id}.md",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    except ValueError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/enforcement/templates/punchlist.md.tera
+++ b/enforcement/templates/punchlist.md.tera
@@ -9,6 +9,7 @@
 
 {% set findings = events | where_eq(attribute="event_type", value="finding") -%}
 {% set resolved_ids = events | where_eq(attribute="event_type", value="finding_resolved") | unique_by(attribute="fields.id") | map(attribute="fields.id") -%}
+{% set deferred_ids = events | where_eq(attribute="event_type", value="finding_deferred") | unique_by(attribute="fields.id") | map(attribute="fields.id") -%}
 
 {% for severity in ["CRITICAL", "HIGH", "MEDIUM", "LOW"] -%}
 {% set sev_findings = findings | where_eq(attribute="fields.severity", value=severity) -%}
@@ -19,7 +20,7 @@
 | ID | Category | Location | Perspective | Description | Status |
 |----|----------|----------|-------------|-------------|--------|
 {% for e in sev_findings -%}
-| {{ e.fields.id }} | {{ e.fields.category }} | {{ e.fields.location }} | {{ e.fields.perspective }} | {{ e.fields.description }} | {% if resolved_ids is containing(e.fields.id) %}RESOLVED{% else %}OPEN{% endif %} |
+| {{ e.fields.id }} | {{ e.fields.category }} | {{ e.fields.location }} | {{ e.fields.perspective }} | {{ e.fields.description }} | {% if resolved_ids is containing(e.fields.id) %}RESOLVED{% elif deferred_ids is containing(e.fields.id) %}DEFERRED{% else %}OPEN{% endif %} |
 {% endfor -%}
 {% endif -%}
 {% endfor %}

--- a/enforcement/templates/status.md.tera
+++ b/enforcement/templates/status.md.tera
@@ -21,4 +21,5 @@
 ## Findings
 {% set finding_count = events | where_eq(attribute="event_type", value="finding") | length -%}
 {% set resolved_count = events | where_eq(attribute="event_type", value="finding_resolved") | unique_by(attribute="fields.id") | length -%}
-**Open:** {{ finding_count - resolved_count }} | **Resolved:** {{ resolved_count }} | **Total:** {{ finding_count }}
+{% set deferred_count = events | where_eq(attribute="event_type", value="finding_deferred") | unique_by(attribute="fields.id") | length -%}
+**Open:** {{ finding_count - resolved_count - deferred_count }} | **Resolved:** {{ resolved_count }} | **Deferred:** {{ deferred_count }} | **Total:** {{ finding_count }}

--- a/enforcement/templates/summary.md.tera
+++ b/enforcement/templates/summary.md.tera
@@ -13,8 +13,10 @@
 {# ── Compute finding counts (unique_by deduplicates by fields.id) ── #}
 {% set findings = events | where_eq(attribute="event_type", value="finding") -%}
 {% set resolutions = events | where_eq(attribute="event_type", value="finding_resolved") | unique_by(attribute="fields.id") -%}
+{% set deferrals = events | where_eq(attribute="event_type", value="finding_deferred") | unique_by(attribute="fields.id") -%}
 {% set finding_count = findings | length -%}
 {% set resolved_count = resolutions | length -%}
+{% set deferred_count = deferrals | length -%}
 {% set fix_iterations = events | where_eq(attribute="event_type", value="state_transition") | where_eq(attribute="fields.command", value="fix_commit") | length -%}
 
 ## Results
@@ -23,7 +25,8 @@
 |--------|-------|
 | Total findings | {{ finding_count }} |
 | Resolved | {{ resolved_count }} |
-| Open at convergence | {{ finding_count - resolved_count }} |
+| Deferred | {{ deferred_count }} |
+| Open at convergence | {{ finding_count - resolved_count - deferred_count }} |
 | Perspectives completed | {{ sets.perspective.completed }} / {{ sets.perspective.total }} |
 | Fix iterations | {{ fix_iterations }} |
 | Protocol violations | {{ violations }} |
@@ -32,32 +35,37 @@
 
 {# ── Count findings per severity (resolved_ids built once above) ── #}
 {% set resolved_ids = resolutions | map(attribute="fields.id") -%}
-| Severity | Found | Resolved |
-|----------|-------|----------|
+{% set deferred_ids = deferrals | map(attribute="fields.id") -%}
+| Severity | Found | Resolved | Deferred |
+|----------|-------|----------|----------|
 {% for severity in ["CRITICAL", "HIGH", "MEDIUM", "LOW"] -%}
 {% set sev_findings = findings | where_eq(attribute="fields.severity", value=severity) -%}
 {% set_global sev_resolved = 0 -%}
+{% set_global sev_deferred = 0 -%}
 {% for e in sev_findings -%}
 {% if resolved_ids is containing(e.fields.id) %}{% set_global sev_resolved = sev_resolved + 1 %}{% endif -%}
+{% if deferred_ids is containing(e.fields.id) %}{% set_global sev_deferred = sev_deferred + 1 %}{% endif -%}
 {% endfor -%}
 {% if sev_findings | length > 0 -%}
-| {{ severity }} | {{ sev_findings | length }} | {{ sev_resolved }} |
+| {{ severity }} | {{ sev_findings | length }} | {{ sev_resolved }} | {{ sev_deferred }} |
 {% endif -%}
 {% endfor %}
 
 ## Findings by Perspective
 
 {# ── Count findings per perspective (reuses resolved_ids from above) ── #}
-| Perspective | Found | Resolved |
-|-------------|-------|----------|
+| Perspective | Found | Resolved | Deferred |
+|-------------|-------|----------|----------|
 {% for m in sets.perspective.members -%}
 {% set persp_findings = findings | where_eq(attribute="fields.perspective", value=m.name) -%}
 {% set_global persp_resolved = 0 -%}
+{% set_global persp_deferred = 0 -%}
 {% for e in persp_findings -%}
 {% if resolved_ids is containing(e.fields.id) %}{% set_global persp_resolved = persp_resolved + 1 %}{% endif -%}
+{% if deferred_ids is containing(e.fields.id) %}{% set_global persp_deferred = persp_deferred + 1 %}{% endif -%}
 {% endfor -%}
 {% if persp_findings | length > 0 -%}
-| {{ m.name }} | {{ persp_findings | length }} | {{ persp_resolved }} |
+| {{ m.name }} | {{ persp_findings | length }} | {{ persp_resolved }} | {{ persp_deferred }} |
 {% endif -%}
 {% endfor %}
 

--- a/enforcement/transitions.toml
+++ b/enforcement/transitions.toml
@@ -85,7 +85,7 @@ gates = [
     { type = "query", sql = "SELECT count(*) >= 1 FROM events WHERE type='finding' AND id='{{item_id}}'", expect = "true", intent = "finding must exist" },
     { type = "query", sql = "SELECT count(*) = 0 FROM events WHERE type IN ('finding_resolved', 'finding_deferred') AND id='{{item_id}}'", expect = "true", intent = "finding must not already be resolved or deferred" },
     { type = "ledger_has_event_since", event = "fix_start", since = "last_transition", intent = "must have started working on this item" },
-    { type = "command_succeeds", cmd = "python enforcement/scripts/check_repro_evidence.py {{item_id}}", intent = "reproduction attempts must be documented in investigation file" },
+    { type = "command_succeeds", cmd = "test -f docs/holtz/investigations/{{item_id}}.md && test -s docs/holtz/investigations/{{item_id}}.md", intent = "reproduction attempts must be documented in investigation file" },
 ]
 
 # ── Deferral: LOW severity ──

--- a/enforcement/transitions.toml
+++ b/enforcement/transitions.toml
@@ -74,6 +74,45 @@ gates = [
     { type = "query", sql = "SELECT count(*) < 15 FROM events WHERE type='state_transition' AND command='fix_commit'", expect = "true", intent = "circuit breaker: max 15 fix iterations" },
 ]
 
+# ── Deferral: can't reproduce ──
+
+[[transitions]]
+from = "fix_loop"
+to = "fix_loop"
+command = "defer_cant_reproduce"
+args = ["item_id"]
+gates = [
+    { type = "query", sql = "SELECT count(*) >= 1 FROM events WHERE type='finding' AND id='{{item_id}}'", expect = "true", intent = "finding must exist" },
+    { type = "query", sql = "SELECT count(*) = 0 FROM events WHERE type IN ('finding_resolved', 'finding_deferred') AND id='{{item_id}}'", expect = "true", intent = "finding must not already be resolved or deferred" },
+    { type = "ledger_has_event_since", event = "fix_start", since = "last_transition", intent = "must have started working on this item" },
+    { type = "command_succeeds", cmd = "python enforcement/scripts/check_repro_evidence.py {{item_id}}", intent = "reproduction attempts must be documented in investigation file" },
+]
+
+# ── Deferral: LOW severity ──
+
+[[transitions]]
+from = "fix_loop"
+to = "fix_loop"
+command = "defer_low"
+args = ["item_id"]
+gates = [
+    { type = "query", sql = "SELECT count(*) >= 1 FROM events WHERE type='finding' AND id='{{item_id}}' AND severity='LOW'", expect = "true", intent = "finding must exist and be LOW severity" },
+    { type = "query", sql = "SELECT count(*) = 0 FROM events WHERE type IN ('finding_resolved', 'finding_deferred') AND id='{{item_id}}'", expect = "true", intent = "finding must not already be resolved or deferred" },
+]
+
+# ── Deferral: MEDIUM severity (budget-capped) ──
+
+[[transitions]]
+from = "fix_loop"
+to = "fix_loop"
+command = "defer_medium"
+args = ["item_id"]
+gates = [
+    { type = "query", sql = "SELECT count(*) >= 1 FROM events WHERE type='finding' AND id='{{item_id}}' AND severity='MEDIUM'", expect = "true", intent = "finding must exist and be MEDIUM severity" },
+    { type = "query", sql = "SELECT count(*) = 0 FROM events WHERE type IN ('finding_resolved', 'finding_deferred') AND id='{{item_id}}'", expect = "true", intent = "finding must not already be resolved or deferred" },
+    { type = "query", sql = "SELECT (SELECT count(*) FROM events WHERE type='finding_deferred' AND reason='medium_budget') < (SELECT count(*) FROM events WHERE type='finding' AND severity='MEDIUM') / 2", expect = "true", intent = "MEDIUM deferrals must not exceed 50% of total MEDIUM findings" },
+]
+
 # ── Context Reset (enforces /clear boundaries) ──
 
 [[transitions]]
@@ -121,7 +160,7 @@ to = "perspective_clean"
 command = "set complete perspective"
 args = ["current_perspective"]
 gates = [
-    { type = "query", sql = "SELECT count(*) FROM events f WHERE f.type='finding' AND f.id NOT IN (SELECT r.id FROM events r WHERE r.type='finding_resolved')", expect = "0", intent = "all findings must be resolved" },
+    { type = "query", sql = "SELECT count(*) FROM events f WHERE f.type='finding' AND f.id NOT IN (SELECT r.id FROM events r WHERE r.type='finding_resolved') AND f.id NOT IN (SELECT d.id FROM events d WHERE d.type='finding_deferred')", expect = "0", intent = "all findings must be resolved or deferred" },
     { type = "query", sql = "SELECT count(*) >= 2 FROM events WHERE type='iteration_complete' AND perspective='{{current_perspective}}'", expect = "true", intent = "two clean iterations required for stability" },
     { type = "min_elapsed", event = "iteration_complete", seconds = 120, intent = "prevent rapid-fire gaming of iteration count" },
     { type = "command_succeeds", cmd = "python -m pytest --tb=short -q", timeout = 120, intent = "tests must pass" },
@@ -165,7 +204,7 @@ gates = [
     { type = "set_covered", set = "perspective", event = "set_member_complete", field = "member", intent = "all lenses must be complete" },
     { type = "command_succeeds", cmd = "python -m pytest --tb=short -q", timeout = 120, intent = "tests must pass" },
     { type = "command_succeeds", cmd = "ruff check .", timeout = 30, intent = "no lint violations" },
-    { type = "query", sql = "SELECT count(*) FROM events f WHERE f.type='finding' AND f.id NOT IN (SELECT r.id FROM events r WHERE r.type='finding_resolved')", expect = "0", intent = "all findings must be resolved" },
+    { type = "query", sql = "SELECT count(*) FROM events f WHERE f.type='finding' AND f.id NOT IN (SELECT r.id FROM events r WHERE r.type='finding_resolved') AND f.id NOT IN (SELECT d.id FROM events d WHERE d.type='finding_deferred')", expect = "0", intent = "all findings must be resolved or deferred" },
     { type = "no_violations", intent = "no unresolved protocol violations" },
     { type = "query", sql = "SELECT count(*) = 0 FROM events e WHERE e.type='quiz_exhausted' AND e.perspective NOT IN (SELECT r.perspective FROM events r WHERE r.type='quiz_exhausted_resolved')", expect = "true", intent = "no unresolved quiz exhaustions" },
 ]

--- a/skills/holtz/references/step-10-fix-loop.md
+++ b/skills/holtz/references/step-10-fix-loop.md
@@ -13,6 +13,7 @@ digraph {
   fast [label="Fast Path\n(test→fix→commit)"]
   investigate [label="Investigation Path\n(layers→confidence→fix)"]
   cantrepro [label="Can't-Reproduce Path\n(widen→bisect→defer)"]
+  defer [label="Priority Deferral\n(LOW or MEDIUM budget)"]
   harden [label="Per-Fix Hardening\n(edges+regression)"]
   blast [label="Blast Radius Analysis\n(impact graph 2-hop)"]
   next [label="Next item"]
@@ -21,10 +22,12 @@ digraph {
   triage -> fast [label="test/doc/design\nor deterministic bug"]
   triage -> investigate [label="intermittent\nor theoretical bug"]
   triage -> cantrepro [label="repro test\nunexpectedly passes"]
+  triage -> defer [label="LOW severity\nor MEDIUM with budget"]
   fast -> harden
   investigate -> harden
   cantrepro -> harden [label="if reproduced"]
-  cantrepro -> next [label="DEFERRED\nwith evidence"]
+  cantrepro -> next [label="sahjhan defer\ncant-reproduce"]
+  defer -> next [label="sahjhan defer\nlow/medium"]
   harden -> blast
   blast -> next
 }
@@ -86,7 +89,34 @@ When the reproduction test passes (bug not triggered), do NOT skip the item. Esc
 
 Log every attempt in the investigation file. Failed reproduction attempts are evidence.
 
-If not reproducible after structured attempts: mark the item DEFERRED with evidence. Do not silently drop it.
+If not reproducible after structured attempts:
+
+1. Ensure reproduction attempts are documented in `docs/holtz/investigations/{item_id}.md`
+2. Run: `sahjhan defer cant-reproduce {item_id}`
+3. Run: `sahjhan event finding_deferred --field id={item_id} --field reason=cant_reproduce --field evidence_path=docs/holtz/investigations/{item_id}.md`
+4. Update PUNCHLIST.md status to DEFERRED
+
+Do not silently drop the item.
+
+## Priority Deferral
+
+For LOW and MEDIUM findings where the fix is legitimate but lower priority than the current audit scope. This is not a shortcut — attempt triage before deferring.
+
+**LOW severity:** All LOW findings may be deferred.
+
+```
+sahjhan defer low {item_id}
+sahjhan event finding_deferred --field id={item_id} --field reason=low_priority
+```
+
+**MEDIUM severity:** Up to half of MEDIUM findings may be deferred. The budget is enforced at deferral time — if the cap is reached, the transition is blocked.
+
+```
+sahjhan defer medium {item_id}
+sahjhan event finding_deferred --field id={item_id} --field reason=medium_budget
+```
+
+HIGH and CRITICAL findings are never deferrable via priority (only via can't-reproduce with evidence).
 
 ## Per-Fix Hardening
 

--- a/tests/test_protocol_enforcement.py
+++ b/tests/test_protocol_enforcement.py
@@ -1082,6 +1082,81 @@ class TestStopHookDaemonCleanup:
         )
 
 
+class TestStopHookDaemonCleanupGating:
+    """Issue #43: awaiting_clear allows stop but must NOT kill daemon."""
+
+    def test_awaiting_clear_does_not_kill_daemon(self, tmp_path):
+        """awaiting_clear: stop allowed, daemon NOT killed (key needed for resume)."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch
+
+        import pytest
+        from _protocol_cache import empty_cache, write_cache
+
+        cache = empty_cache()
+        cache["state"] = "awaiting_clear"
+        cache["last_sahjhan_cmd"] = datetime.now(timezone.utc).isoformat()  # noqa: UP017
+        write_cache(str(tmp_path), cache)
+
+        import stop_hook
+        with (
+            patch.object(stop_hook, "_try_stop_daemon") as mock_stop,
+            patch.object(stop_hook, "read_event", return_value={"cwd": str(tmp_path)}),
+            patch.object(stop_hook, "_has_active_audit", return_value=True),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                stop_hook.main()
+            assert exc_info.value.code == 0
+        mock_stop.assert_not_called()
+
+    def test_idle_still_kills_daemon(self, tmp_path):
+        """idle: stop allowed AND daemon killed (no audit to resume)."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch
+
+        import pytest
+        from _protocol_cache import empty_cache, write_cache
+
+        cache = empty_cache()
+        cache["state"] = "idle"
+        cache["last_sahjhan_cmd"] = datetime.now(timezone.utc).isoformat()  # noqa: UP017
+        write_cache(str(tmp_path), cache)
+
+        import stop_hook
+        with (
+            patch.object(stop_hook, "_try_stop_daemon") as mock_stop,
+            patch.object(stop_hook, "read_event", return_value={"cwd": str(tmp_path)}),
+            patch.object(stop_hook, "_has_active_audit", return_value=True),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                stop_hook.main()
+            assert exc_info.value.code == 0
+        mock_stop.assert_called_once()
+
+    def test_stale_awaiting_clear_does_not_kill_daemon(self, tmp_path):
+        """Stale awaiting_clear: still allows stop, does NOT kill daemon."""
+        from unittest.mock import patch
+
+        import pytest
+        from _protocol_cache import empty_cache, write_cache
+
+        cache = empty_cache()
+        cache["state"] = "awaiting_clear"
+        cache["last_sahjhan_cmd"] = "2025-01-01T00:00:00+00:00"  # very stale
+        write_cache(str(tmp_path), cache)
+
+        import stop_hook
+        with (
+            patch.object(stop_hook, "_try_stop_daemon") as mock_stop,
+            patch.object(stop_hook, "read_event", return_value={"cwd": str(tmp_path)}),
+            patch.object(stop_hook, "_has_active_audit", return_value=True),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                stop_hook.main()
+            assert exc_info.value.code == 0
+        mock_stop.assert_not_called()
+
+
 class TestExitEnforcementError:
     """Tests for exit_enforcement_error() shared utility."""
 

--- a/tests/test_protocol_enforcement.py
+++ b/tests/test_protocol_enforcement.py
@@ -1133,8 +1133,8 @@ class TestStopHookDaemonCleanupGating:
             assert exc_info.value.code == 0
         mock_stop.assert_called_once()
 
-    def test_stale_awaiting_clear_does_not_kill_daemon(self, tmp_path):
-        """Stale awaiting_clear: still allows stop, does NOT kill daemon."""
+    def test_stale_awaiting_clear_takes_allowed_path_without_daemon_kill(self, tmp_path):
+        """Stale awaiting_clear hits _STOP_ALLOWED_STATES (not staleness path), daemon survives."""
         from unittest.mock import patch
 
         import pytest

--- a/tests/test_repro_evidence.py
+++ b/tests/test_repro_evidence.py
@@ -1,0 +1,33 @@
+"""Tests for check_repro_evidence.py."""
+from __future__ import annotations
+
+from enforcement.scripts.check_repro_evidence import check_repro_evidence
+
+
+def test_investigation_file_exists(tmp_path):
+    """Investigation file present — evidence sufficient."""
+    inv = tmp_path / "investigations" / "BH-042.md"
+    inv.parent.mkdir(parents=True)
+    inv.write_text("## Reproduction Attempts\n\n- Ran test 100x, 0 failures\n")
+    assert check_repro_evidence("BH-042", str(tmp_path)) is True
+
+
+def test_no_investigation_file_fails(tmp_path):
+    """No investigation file and no evidence — fails."""
+    assert check_repro_evidence("BH-042", str(tmp_path)) is False
+
+
+def test_empty_investigation_file_fails(tmp_path):
+    """Empty investigation file is not evidence."""
+    inv = tmp_path / "investigations" / "BH-042.md"
+    inv.parent.mkdir(parents=True)
+    inv.write_text("")
+    assert check_repro_evidence("BH-042", str(tmp_path)) is False
+
+
+def test_invalid_finding_id_raises():
+    """Invalid finding ID format raises ValueError."""
+    import pytest
+
+    with pytest.raises(ValueError, match="Invalid finding ID"):
+        check_repro_evidence("BOGUS", "/tmp")


### PR DESCRIPTION
## Summary

- **Fix: stop hook kills daemon in `awaiting_clear` state** (#43) — separated "allowed to stop" from "safe to kill daemon" by introducing `_DAEMON_CLEANUP_STATES`. Audits can now resume after `/clear`.
- **Feature: finding deferral protocol** — `defer_cant_reproduce`, `defer_low`, `defer_medium` transitions with enforcement gates, deferral procedures in step-10 fix loop
- **Fix: repro evidence gate** — use shell builtins instead of subprocess for reliability
- **Fix: background daemon start** — phase-recon instructions now background the daemon

## Test plan
- [x] 1020 tests pass (3 new for issue #43)
- [x] ruff clean
- [x] mypy clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)