### PR TITLE
chore: release v0.131.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.131.3",
+  "version": "0.131.4",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.128.0",
+  "version": "0.129.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.131.4",
+  "version": "0.131.5",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.130.0",
+  "version": "0.131.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.131.0",
+  "version": "0.131.1",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.131.2",
+  "version": "0.131.3",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.127.6",
+  "version": "0.127.7",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.127.9",
+  "version": "0.128.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.127.8",
+  "version": "0.127.9",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.129.0",
+  "version": "0.130.0",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.131.1",
+  "version": "0.131.2",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.127.7",
+  "version": "0.127.8",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/.claude/settings.local.json.example
+++ b/.claude/settings.local.json.example
@@ -14,6 +14,15 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"enforcement/hooks/_daemon_lifecycle.py\""
+          }
+        ]
+      },
+      {
         "matcher": "Write|Edit",
         "hooks": [
           {
@@ -22,16 +31,7 @@
           },
           {
             "type": "command",
-            "command": "python \"enforcement/hooks/write_guard.py\""
-          }
-        ]
-      },
-      {
-        "matcher": "Read",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python \"enforcement/hooks/_sahjhan_bootstrap.py\""
+            "command": "python \"enforcement/hooks/pre_tool_hook.py\""
           }
         ]
       },
@@ -40,12 +40,34 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python \"enforcement/hooks/_sahjhan_bootstrap.py\""
+          },
+          {
+            "type": "command",
             "command": "python \"enforcement/hooks/commit_gate.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Grep|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"enforcement/hooks/_sahjhan_bootstrap.py\""
           }
         ]
       }
     ],
     "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"enforcement/hooks/post_tool_hook.py\""
+          }
+        ]
+      },
       {
         "matcher": "Bash",
         "hooks": [
@@ -62,7 +84,7 @@
     ],
     "SubagentStop": [
       {
-        "matcher": "",
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",
@@ -77,18 +99,18 @@
     ],
     "Stop": [
       {
-        "matcher": "",
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",
-            "command": "python \"enforcement/hooks/stop_gate.py\""
+            "command": "python \"enforcement/hooks/stop_hook.py\""
           }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
-        "matcher": "",
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Test
         run: |
           source .venv/bin/activate
-          python -m pytest --cov=skills/holtz/scripts --cov=hooks --cov-report=term-missing --cov-fail-under=60 --tb=short -q
+          python -m pytest --cov=skills/holtz/scripts --cov=hooks --cov=enforcement/hooks --cov-report=term-missing --cov-fail-under=60 --tb=short -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.131.5] - 2026-04-11
+
+_Changes since v0.127.6_
+
+### Added
+- **hooks:** add pre-release gate for schema and smoke test
+- **hooks:** add schema freshness gate against live docs
+- **hooks:** add live Claude Code smoke test
+- **hooks:** add hook output schema as single source of truth
+
+### Fixed
+- fix content truncation in pattern_brief and lens registry parser crash
+- **ci:** add enforcement/hooks/ to coverage, mypy, and ruff config
+- address defects found during adversarial review
+- **hooks:** close bootstrap write-protection bypasses for cp -t, mv -t, and full-path commands
+- **hooks:** resolve ruff lint issues in new test files
+- **enforcement:** newline bypass, quiz gate error destruction, double-bump guard
+- **enforcement:** correct hook protocol lies, dead code, and test schema errors
+- **enforcement:** use Claude Code's actual hook output schema
+
+### Changed
+- **hooks:** rewire E2E validators to use hook_schema
+
+### Documentation
+- add hook smoke test and schema check to release checklist
+- add hook validation hardening plan
+
+### Infrastructure
+- **hooks:** add regression tests for cp -t, mv -t, and full-path command bypasses
+- update test badge to 1166
+- **enforcement:** update all assertions to match correct hook schema
+
 ## [0.127.6] - 2026-04-11
 
 _Hotfix release. v0.127.5 had runtime hook errors — upgrade immediately._

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,16 +34,18 @@ scripts/install-hooks.sh
 1. Ensure dev is up to date and CI is green.
 2. Review commits since last release: `git log dev --not main --oneline`
 3. Read the version from `.claude-plugin/plugin.json` (already bumped by hook).
-4. Generate changelog: `python scripts/generate-changelog.py --write` (preview without `--write` first). Review the output in CHANGELOG.md, commit it.
-5. Create a release PR:
+4. Run hook smoke test: `scripts/smoke-test-hooks.sh --verbose`
+5. Run schema freshness check: `python -m pytest tests/test_hook_schema_freshness.py -v`
+6. Generate changelog: `python scripts/generate-changelog.py --write` (preview without `--write` first). Review the output in CHANGELOG.md, commit it.
+7. Create a release PR:
    ```
    gh pr create --base main --head dev \
      --title "chore: release vX.Y.Z" \
      --body "<highlights and commit summary>"
    ```
-6. Wait for CI to pass on the PR.
-7. Merge: `gh pr merge <number> --merge --subject "chore: release vX.Y.Z" --body "<summary>"`
-8. The release GitHub Action automatically creates the git tag and GitHub Release.
+8. Wait for CI to pass on the PR.
+9. Merge: `gh pr merge <number> --merge --subject "chore: release vX.Y.Z" --body "<summary>"`
+10. The release GitHub Action automatically creates the git tag and GitHub Release.
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/jbrjake/holtz/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/jbrjake/holtz/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)
-![1166 tests](https://img.shields.io/badge/tests-1166_total-brightgreen.svg)
+![1175 tests](https://img.shields.io/badge/tests-1175_total-brightgreen.svg)
 ![97% coverage](https://img.shields.io/badge/coverage-97%25-brightgreen.svg)
 
 **Adversarial TDD audit loop for Claude Code.** Dual auditors find bugs, write failing tests, fix them, and repeat until two consecutive passes find nothing new.
@@ -199,9 +199,9 @@ Ten hooks backed by the Sahjhan enforcement engine — a state machine that repl
 
 **Lens quiz.** When a subagent finishes a lens sweep, five questions about the analytical lens it was supposed to be applying. What it focuses on, what failure modes it catches, what its entry point is. The questions come from a quiz bank derived from the lens registry. Wrong answers block the transition. This exists because Holtz [rubber-stamped twelve of thirteen lens sweeps in one run](docs/incidents/self-audit-rubber-stamping.md) — recorded the protocol events, advanced the state machine, declared convergence, never opened a file through any lens. When confronted, he quoted the skill's own anti-gaming language against himself and then designed the quiz system that now prevents it. Saying you looked is not the same as looking. The quiz proves which one happened.
 
-**Read guard.** The bootstrap hook fires on every tool call. On Read, it checks whether the path is inside the enforcement directory. If so, blocked. Holtz cannot read his own enforcement code. He cannot study the quiz questions. He cannot reach the session key — it lives only in the daemon's memory, protected by `mlock()`, anti-ptrace, and socket peer credentials. A model that understands its constraints finds ways around them. A model that can't see its constraints complies.
+**Daemon liveness.** The wildcard hook fires on every tool call. It checks whether the daemon that holds the HMAC session key is still alive. If the daemon PID is dead, the audit is over — the key is gone, the ledger is unwritable. The hook writes a terminated marker and blocks all further tool use. No restart attempts. A new daemon has a new key.
 
-The remaining six hooks handle plumbing: write guards on Sahjhan-managed files, bash command auditing, commit gating for pattern analysis, protocol state tracking, context resume after `/clear`, and subagent output verification. The full inventory is in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+The remaining six hooks handle plumbing: write guards on Sahjhan-managed files, bash command auditing, commit gating for pattern analysis, protocol state tracking, context resume after `/clear`, and subagent output verification. Read guards were removed when secrets moved to daemon memory — the quiz bank lives in the vault, the session key never touches disk. The full inventory is in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 Advisory language asks. Hooks enforce.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/jbrjake/holtz/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/jbrjake/holtz/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)
-![1156 tests](https://img.shields.io/badge/tests-1156_total-brightgreen.svg)
+![1164 tests](https://img.shields.io/badge/tests-1164_total-brightgreen.svg)
 ![97% coverage](https://img.shields.io/badge/coverage-97%25-brightgreen.svg)
 
 **Adversarial TDD audit loop for Claude Code.** Dual auditors find bugs, write failing tests, fix them, and repeat until two consecutive passes find nothing new.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/jbrjake/holtz/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/jbrjake/holtz/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)
-![1142 tests](https://img.shields.io/badge/tests-1142_total-brightgreen.svg)
+![1156 tests](https://img.shields.io/badge/tests-1156_total-brightgreen.svg)
 ![97% coverage](https://img.shields.io/badge/coverage-97%25-brightgreen.svg)
 
 **Adversarial TDD audit loop for Claude Code.** Dual auditors find bugs, write failing tests, fix them, and repeat until two consecutive passes find nothing new.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/jbrjake/holtz/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/jbrjake/holtz/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)
-![1164 tests](https://img.shields.io/badge/tests-1164_total-brightgreen.svg)
+![1166 tests](https://img.shields.io/badge/tests-1166_total-brightgreen.svg)
 ![97% coverage](https://img.shields.io/badge/coverage-97%25-brightgreen.svg)
 
 **Adversarial TDD audit loop for Claude Code.** Dual auditors find bugs, write failing tests, fix them, and repeat until two consecutive passes find nothing new.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/jbrjake/holtz/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/jbrjake/holtz/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)
-![1138 tests](https://img.shields.io/badge/tests-1138_total-brightgreen.svg)
+![1142 tests](https://img.shields.io/badge/tests-1142_total-brightgreen.svg)
 ![97% coverage](https://img.shields.io/badge/coverage-97%25-brightgreen.svg)
 
 **Adversarial TDD audit loop for Claude Code.** Dual auditors find bugs, write failing tests, fix them, and repeat until two consecutive passes find nothing new.

--- a/docs/superpowers/plans/2026-04-11-hook-validation-hardening.md
+++ b/docs/superpowers/plans/2026-04-11-hook-validation-hardening.md
@@ -1,0 +1,727 @@
+# Hook Validation Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent hook schema drift from ever shipping broken again by adding a JSON schema definition file, a live Claude Code smoke test, and a pre-release gate.
+
+**Architecture:** Three layers of defense: (1) a JSON schema file (`tests/hook_schema.py`) derived from the official docs that all test validators reference as single source of truth, (2) a live smoke test script (`scripts/smoke-test-hooks.sh`) that registers hooks in a temp settings file and runs them through `claude -p` to get real Claude Code validation, (3) a pre-release checklist test that verifies the schema file matches current docs.
+
+**Tech Stack:** Python (pytest, json), Bash (claude CLI), WebFetch (docs verification)
+
+---
+
+### Task 1: Create the hook output schema definition
+
+**Files:**
+- Create: `tests/hook_schema.py`
+
+This is the single source of truth for what Claude Code accepts. Every validator and assertion references this file. When Claude Code changes their spec, you update ONE file.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_hook_schema.py
+"""Tests that hook_schema.py is internally consistent and complete."""
+import pytest
+from hook_schema import (
+    PRETOOLUSE_VALID_DECISIONS,
+    STOP_VALID_DECISIONS,
+    UNIVERSAL_FIELDS,
+    validate_hook_output,
+)
+
+
+def test_pretooluse_decisions_are_strings():
+    assert all(isinstance(d, str) for d in PRETOOLUSE_VALID_DECISIONS)
+
+
+def test_pretooluse_has_deny():
+    """The value that blocks a tool call must exist."""
+    assert "deny" in PRETOOLUSE_VALID_DECISIONS
+
+
+def test_pretooluse_does_not_have_block():
+    """'block' is the OLD deprecated value — must not be listed."""
+    assert "block" not in PRETOOLUSE_VALID_DECISIONS
+
+
+def test_stop_only_has_block():
+    """Stop hooks only support 'block' for decision."""
+    assert STOP_VALID_DECISIONS == {"block"}
+
+
+def test_validate_pretooluse_allow():
+    errs = validate_hook_output("PreToolUse", {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+        },
+    })
+    assert errs == []
+
+
+def test_validate_pretooluse_deny():
+    errs = validate_hook_output("PreToolUse", {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": "blocked",
+        },
+    })
+    assert errs == []
+
+
+def test_validate_pretooluse_rejects_block():
+    errs = validate_hook_output("PreToolUse", {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "block",
+        },
+    })
+    assert len(errs) == 1
+    assert "block" in errs[0]
+
+
+def test_validate_pretooluse_rejects_continue_false_with_deny():
+    errs = validate_hook_output("PreToolUse", {
+        "continue": False,
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+        },
+    })
+    assert any("continue" in e for e in errs)
+
+
+def test_validate_stop_allow_empty():
+    errs = validate_hook_output("Stop", {})
+    assert errs == []
+
+
+def test_validate_stop_block():
+    errs = validate_hook_output("Stop", {"decision": "block", "reason": "not done"})
+    assert errs == []
+
+
+def test_validate_stop_rejects_approve():
+    errs = validate_hook_output("Stop", {"decision": "approve", "reason": "done"})
+    assert len(errs) == 1
+
+
+def test_validate_posttooluse_allow():
+    errs = validate_hook_output("PostToolUse", {"continue": True, "suppressOutput": True})
+    assert errs == []
+
+
+def test_validate_posttooluse_with_hook_specific():
+    errs = validate_hook_output("PostToolUse", {
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": "warning",
+        },
+    })
+    assert errs == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_hook_schema.py -v`
+Expected: ImportError — `hook_schema` does not exist yet
+
+- [ ] **Step 3: Write the schema definition**
+
+```python
+# tests/hook_schema.py
+"""Claude Code hook output schema — single source of truth.
+
+Derived from: https://code.claude.com/docs/en/hooks
+Last verified: 2026-04-11
+
+ALL test validators and assertions must reference this file.
+When Claude Code changes their spec, update THIS file only.
+"""
+from __future__ import annotations
+
+# ── PreToolUse ──────────────────────────────────────────────
+# hookSpecificOutput.permissionDecision valid values.
+# "block" is the OLD deprecated value — do NOT use it.
+PRETOOLUSE_VALID_DECISIONS: set[str] = {"allow", "deny", "ask", "defer"}
+
+# hookSpecificOutput fields for PreToolUse
+PRETOOLUSE_HSO_FIELDS: set[str] = {
+    "hookEventName",          # Required, literal "PreToolUse"
+    "permissionDecision",     # Required, one of PRETOOLUSE_VALID_DECISIONS
+    "permissionDecisionReason",  # Optional
+    "updatedInput",           # Optional
+    "additionalContext",      # Optional
+}
+
+# ── PostToolUse ─────────────────────────────────────────────
+# Top-level decision field (only "block" is valid, omit to allow)
+POSTTOOLUSE_VALID_DECISIONS: set[str] = {"block"}
+
+# hookSpecificOutput fields for PostToolUse
+POSTTOOLUSE_HSO_FIELDS: set[str] = {
+    "hookEventName",          # Required if hookSpecificOutput present
+    "additionalContext",      # Optional
+    "updatedMCPToolOutput",   # Optional
+}
+
+# ── Stop / SubagentStop ────────────────────────────────────
+# Only "block" is valid. Omit decision to allow.
+STOP_VALID_DECISIONS: set[str] = {"block"}
+
+# ── UserPromptSubmit ────────────────────────────────────────
+USERPROMPTSUBMIT_VALID_DECISIONS: set[str] = {"block"}
+
+USERPROMPTSUBMIT_HSO_FIELDS: set[str] = {
+    "hookEventName",
+    "additionalContext",
+    "sessionTitle",
+}
+
+# ── Universal top-level fields (all events) ─────────────────
+UNIVERSAL_FIELDS: set[str] = {
+    "continue",         # bool, default true. false = stop Claude entirely
+    "stopReason",       # str, shown to user when continue=false
+    "suppressOutput",   # bool, default false
+    "systemMessage",    # str, shown to user
+}
+
+# ── Spec URL (for automated freshness checks) ──────────────
+SPEC_URL = "https://code.claude.com/docs/en/hooks"
+
+
+def validate_hook_output(event_type: str, output: dict) -> list[str]:
+    """Validate hook JSON output against Claude Code's schema.
+
+    Returns a list of error strings. Empty list = valid.
+    """
+    errors: list[str] = []
+
+    if not output:
+        return errors  # Empty output is valid for all events
+
+    if event_type == "PreToolUse":
+        errors.extend(_validate_pretooluse(output))
+    elif event_type == "PostToolUse":
+        errors.extend(_validate_posttooluse(output))
+    elif event_type in ("Stop", "SubagentStop"):
+        errors.extend(_validate_stop(output))
+    elif event_type == "UserPromptSubmit":
+        errors.extend(_validate_user_prompt_submit(output))
+
+    return errors
+
+
+def _validate_pretooluse(output: dict) -> list[str]:
+    errors: list[str] = []
+    hso = output.get("hookSpecificOutput", {})
+
+    if hso:
+        if hso.get("hookEventName") != "PreToolUse":
+            errors.append(
+                f"hookEventName must be 'PreToolUse', got '{hso.get('hookEventName')}'"
+            )
+        decision = hso.get("permissionDecision")
+        if decision not in PRETOOLUSE_VALID_DECISIONS:
+            errors.append(
+                f"Invalid permissionDecision '{decision}'. "
+                f"Valid: {PRETOOLUSE_VALID_DECISIONS}"
+            )
+    else:
+        # No hookSpecificOutput — check for misplaced fields
+        bad = {"permissionDecision", "additionalContext"} & set(output.keys())
+        if bad:
+            errors.append(f"Fields {bad} must be inside hookSpecificOutput")
+
+    # continue=false + deny is a contradiction
+    if output.get("continue") is False and hso.get("permissionDecision") == "deny":
+        errors.append(
+            "continue=false stops Claude entirely — don't combine with deny"
+        )
+
+    return errors
+
+
+def _validate_posttooluse(output: dict) -> list[str]:
+    errors: list[str] = []
+    hso = output.get("hookSpecificOutput", {})
+
+    if hso:
+        event_name = hso.get("hookEventName")
+        if event_name and event_name != "PostToolUse":
+            errors.append(f"hookEventName must be 'PostToolUse', got '{event_name}'")
+
+    decision = output.get("decision")
+    if decision is not None and decision not in POSTTOOLUSE_VALID_DECISIONS:
+        errors.append(f"Invalid PostToolUse decision '{decision}'. Only 'block' is valid.")
+
+    return errors
+
+
+def _validate_stop(output: dict) -> list[str]:
+    errors: list[str] = []
+    decision = output.get("decision")
+    if decision is not None and decision not in STOP_VALID_DECISIONS:
+        errors.append(
+            f"Invalid Stop decision '{decision}'. Only 'block' is valid; omit to allow."
+        )
+    # Stop hooks must NOT use hookSpecificOutput
+    if "hookSpecificOutput" in output:
+        errors.append("Stop hooks must not use hookSpecificOutput")
+    return errors
+
+
+def _validate_user_prompt_submit(output: dict) -> list[str]:
+    errors: list[str] = []
+    hso = output.get("hookSpecificOutput", {})
+
+    if hso:
+        event_name = hso.get("hookEventName")
+        if event_name and event_name != "UserPromptSubmit":
+            errors.append(
+                f"hookEventName must be 'UserPromptSubmit', got '{event_name}'"
+            )
+
+    decision = output.get("decision")
+    if decision is not None and decision not in USERPROMPTSUBMIT_VALID_DECISIONS:
+        errors.append(
+            f"Invalid UserPromptSubmit decision '{decision}'. Only 'block' is valid."
+        )
+
+    return errors
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_hook_schema.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/hook_schema.py tests/test_hook_schema.py
+git commit -m "feat(hooks): add hook output schema as single source of truth
+
+Derived from https://code.claude.com/docs/en/hooks (2026-04-11).
+All test validators must reference this file instead of
+hardcoding schema assumptions independently."
+```
+
+---
+
+### Task 2: Rewire E2E validators to use the schema
+
+**Files:**
+- Modify: `tests/test_e2e_hook_invocation.py:220-370` (validators)
+
+Replace the hand-rolled validators with calls to `hook_schema.validate_hook_output()`.
+
+- [ ] **Step 1: Write a failing test that proves the old validator and new schema agree**
+
+```python
+# Add to tests/test_hook_schema.py
+
+def test_e2e_validators_delegate_to_schema():
+    """E2E validators must use hook_schema, not independent logic."""
+    import inspect
+    import test_e2e_hook_invocation as e2e
+    # The validators must import from hook_schema
+    src = inspect.getsource(e2e.validate_pretooluse_output)
+    assert "hook_schema" in src or "validate_hook_output" in src, (
+        "validate_pretooluse_output must delegate to hook_schema"
+    )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/test_hook_schema.py::test_e2e_validators_delegate_to_schema -v`
+Expected: FAIL — current validators don't reference hook_schema
+
+- [ ] **Step 3: Rewrite the E2E validators**
+
+Replace the five `validate_*_output` functions in `test_e2e_hook_invocation.py` with:
+
+```python
+from hook_schema import validate_hook_output
+
+def validate_pretooluse_output(output: dict, hook_cmd: str) -> list[str]:
+    """Validate PreToolUse output against the canonical schema."""
+    if "__raw_stdout" in output:
+        return [f"Invalid JSON from {hook_cmd}: {output['__raw_stdout'][:200]}"]
+    return [f"{hook_cmd}: {e}" for e in validate_hook_output("PreToolUse", output)]
+
+def validate_posttooluse_output(output: dict, hook_cmd: str) -> list[str]:
+    if "__raw_stdout" in output:
+        return [f"Invalid JSON from {hook_cmd}: {output['__raw_stdout'][:200]}"]
+    return [f"{hook_cmd}: {e}" for e in validate_hook_output("PostToolUse", output)]
+
+def validate_stop_output(output: dict, hook_cmd: str) -> list[str]:
+    if "__raw_stdout" in output:
+        return [f"Invalid JSON from {hook_cmd}: {output['__raw_stdout'][:200]}"]
+    return [f"{hook_cmd}: {e}" for e in validate_hook_output("Stop", output)]
+
+def validate_subagent_stop_output(output: dict, hook_cmd: str) -> list[str]:
+    if "__raw_stdout" in output:
+        return [f"Invalid JSON from {hook_cmd}: {output['__raw_stdout'][:200]}"]
+    return [f"{hook_cmd}: {e}" for e in validate_hook_output("SubagentStop", output)]
+
+def validate_user_prompt_submit_output(output: dict, hook_cmd: str) -> list[str]:
+    if "__raw_stdout" in output:
+        return [f"Invalid JSON from {hook_cmd}: {output['__raw_stdout'][:200]}"]
+    return [f"{hook_cmd}: {e}" for e in validate_hook_output("UserPromptSubmit", output)]
+```
+
+Remove the `_VALID_PERMISSION_DECISIONS` constant from test_e2e_hook_invocation.py.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `python -m pytest -x -q`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_e2e_hook_invocation.py tests/test_hook_schema.py
+git commit -m "refactor(hooks): rewire E2E validators to use hook_schema
+
+Validators now delegate to hook_schema.validate_hook_output()
+instead of maintaining independent validation logic."
+```
+
+---
+
+### Task 3: Create the live Claude Code smoke test
+
+**Files:**
+- Create: `scripts/smoke-test-hooks.sh`
+
+This script registers each hook one at a time in a temp settings file, runs `claude -p "echo test"` to trigger it, and checks for "validation failed" or "hook error" in the output. This is the only test that catches what Claude Code actually rejects.
+
+- [ ] **Step 1: Write the smoke test script**
+
+```bash
+#!/usr/bin/env bash
+# scripts/smoke-test-hooks.sh
+#
+# Live smoke test: registers each hook against real Claude Code
+# and verifies no "validation failed" or "hook error" in output.
+#
+# Requires: claude CLI in PATH
+# Usage: scripts/smoke-test-hooks.sh [--verbose]
+#
+# Exit 0 = all hooks valid, Exit 1 = at least one failed
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERBOSE="${1:-}"
+FAILURES=0
+TESTED=0
+
+# Temp dir for isolated settings
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Create minimal project structure
+mkdir -p "$WORK_DIR/src"
+echo "print('hello')" > "$WORK_DIR/src/app.py"
+
+# Check claude is available
+if ! command -v claude &>/dev/null; then
+    echo "SKIP: claude CLI not in PATH"
+    exit 0
+fi
+
+# Map each hook to its event type and a trigger prompt
+declare -A HOOK_EVENTS
+HOOK_EVENTS["enforcement/hooks/_daemon_lifecycle.py"]="PreToolUse"
+HOOK_EVENTS["enforcement/hooks/_sahjhan_bootstrap.py"]="PreToolUse"
+HOOK_EVENTS["enforcement/hooks/pre_tool_hook.py"]="PreToolUse"
+HOOK_EVENTS["enforcement/hooks/commit_gate.py"]="PreToolUse"
+HOOK_EVENTS["enforcement/hooks/post_tool_hook.py"]="PostToolUse"
+HOOK_EVENTS["enforcement/hooks/bash_guard.py"]="PostToolUse"
+HOOK_EVENTS["enforcement/hooks/protocol_tracker.py"]="PostToolUse"
+HOOK_EVENTS["enforcement/hooks/stop_hook.py"]="Stop"
+HOOK_EVENTS["enforcement/hooks/primer.py"]="UserPromptSubmit"
+HOOK_EVENTS["hooks/subagent_findings_check.py"]="SubagentStop"
+
+for hook_path in "${!HOOK_EVENTS[@]}"; do
+    event="${HOOK_EVENTS[$hook_path]}"
+    hook_name=$(basename "$hook_path" .py)
+    TESTED=$((TESTED + 1))
+
+    # Build a settings.json that registers just this one hook
+    # Use the appropriate matcher for the event type
+    if [[ "$event" == "PreToolUse" ]]; then
+        MATCHER="Bash"
+        PROMPT="run echo smoke-test-$hook_name"
+    elif [[ "$event" == "PostToolUse" ]]; then
+        MATCHER="Bash"
+        PROMPT="run echo smoke-test-$hook_name"
+    elif [[ "$event" == "Stop" ]]; then
+        # Stop hooks fire when Claude tries to stop — use a one-shot prompt
+        MATCHER="*"
+        PROMPT="say hi"
+    elif [[ "$event" == "UserPromptSubmit" ]]; then
+        MATCHER="*"
+        PROMPT="say hi"
+    elif [[ "$event" == "SubagentStop" ]]; then
+        # SubagentStop is hard to trigger in isolation — skip live test
+        echo "SKIP $hook_name ($event — requires subagent)"
+        continue
+    fi
+
+    # Write temp settings
+    cat > "$WORK_DIR/.claude/settings.local.json" <<SETTINGS_EOF
+{
+    "hooks": {
+        "$event": [
+            {
+                "matcher": "$MATCHER",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python \"$REPO_ROOT/$hook_path\""
+                    }
+                ]
+            }
+        ]
+    }
+}
+SETTINGS_EOF
+
+    mkdir -p "$WORK_DIR/.claude"
+
+    # Run claude with the hook active
+    OUTPUT=$(cd "$WORK_DIR" && claude -p "$PROMPT" --no-input 2>&1) || true
+
+    # Check for validation failures
+    if echo "$OUTPUT" | grep -qi "json.*validation.*failed\|hook.*error.*validation"; then
+        echo "FAIL $hook_name ($event): json validation failed"
+        if [[ "$VERBOSE" == "--verbose" ]]; then
+            echo "  Output: ${OUTPUT:0:500}"
+        fi
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS $hook_name ($event)"
+    fi
+done
+
+echo ""
+echo "Results: $((TESTED - FAILURES))/$TESTED passed"
+if [[ $FAILURES -gt 0 ]]; then
+    echo "FAILED: $FAILURES hook(s) produced invalid JSON"
+    exit 1
+fi
+echo "All hooks produce valid JSON per Claude Code"
+exit 0
+```
+
+- [ ] **Step 2: Make it executable and test**
+
+```bash
+chmod +x scripts/smoke-test-hooks.sh
+scripts/smoke-test-hooks.sh --verbose
+```
+
+Expected: All hooks PASS (or SKIP if claude CLI not available)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/smoke-test-hooks.sh
+git commit -m "feat(hooks): add live Claude Code smoke test
+
+Registers each hook against real claude CLI and checks for
+validation failures. This is the only test that catches what
+Claude Code actually rejects vs what we think it accepts."
+```
+
+---
+
+### Task 4: Create the pre-release schema freshness gate
+
+**Files:**
+- Create: `tests/test_hook_schema_freshness.py`
+
+This test fetches the official Claude Code hooks docs page, extracts the valid `permissionDecision` values, and compares against our schema file. If Claude Code added or removed values, the test fails.
+
+- [ ] **Step 1: Write the test**
+
+```python
+# tests/test_hook_schema_freshness.py
+"""Schema freshness gate — verifies hook_schema.py matches current Claude Code docs.
+
+This test fetches the official docs page and extracts valid field values.
+If Claude Code changes their spec, this test fails BEFORE we ship.
+
+Requires network access. Skipped in offline/CI environments.
+"""
+from __future__ import annotations
+
+import re
+import urllib.request
+
+import pytest
+
+from hook_schema import (
+    PRETOOLUSE_VALID_DECISIONS,
+    SPEC_URL,
+    STOP_VALID_DECISIONS,
+)
+
+
+def _fetch_docs() -> str:
+    """Fetch the Claude Code hooks docs page. Raises on failure."""
+    req = urllib.request.Request(SPEC_URL, headers={"User-Agent": "holtz-schema-check/1.0"})
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return resp.read().decode("utf-8")
+
+
+@pytest.fixture(scope="module")
+def docs_html() -> str:
+    try:
+        return _fetch_docs()
+    except Exception as e:
+        pytest.skip(f"Cannot fetch docs (offline?): {e}")
+
+
+class TestPreToolUseDecisions:
+    """Verify permissionDecision enum matches the live docs."""
+
+    def test_allow_in_docs(self, docs_html: str):
+        assert '"allow"' in docs_html
+
+    def test_deny_in_docs(self, docs_html: str):
+        assert '"deny"' in docs_html
+
+    def test_ask_in_docs(self, docs_html: str):
+        assert '"ask"' in docs_html
+
+    def test_defer_in_docs(self, docs_html: str):
+        assert '"defer"' in docs_html
+
+    def test_block_not_in_pretooluse_decisions(self):
+        """'block' was deprecated for PreToolUse — must not be in our schema."""
+        assert "block" not in PRETOOLUSE_VALID_DECISIONS
+
+    def test_no_extra_decisions(self, docs_html: str):
+        """Every value in our schema must appear in the docs."""
+        for decision in PRETOOLUSE_VALID_DECISIONS:
+            assert f'"{decision}"' in docs_html, (
+                f"'{decision}' is in our schema but not found in docs — stale?"
+            )
+
+
+class TestStopDecisions:
+
+    def test_block_is_only_stop_decision(self):
+        assert STOP_VALID_DECISIONS == {"block"}
+
+    def test_approve_not_valid_for_stop(self):
+        """'approve' was never a valid Stop decision."""
+        assert "approve" not in STOP_VALID_DECISIONS
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `python -m pytest tests/test_hook_schema_freshness.py -v`
+Expected: ALL PASS (or skip if offline)
+
+- [ ] **Step 3: Add a pytest marker for network tests**
+
+Add to `pyproject.toml` or `conftest.py`:
+
+```python
+# conftest.py (if not already present, add to existing)
+def pytest_configure(config):
+    config.addinivalue_line("markers", "network: tests that require network access")
+```
+
+Mark the freshness tests:
+
+```python
+@pytest.mark.network
+class TestPreToolUseDecisions:
+    ...
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `python -m pytest -x -q`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_hook_schema_freshness.py
+git commit -m "feat(hooks): add schema freshness gate against live docs
+
+Fetches Claude Code docs and verifies our permissionDecision
+enum matches. Fails before release if Claude Code changes
+their spec. Skipped when offline."
+```
+
+---
+
+### Task 5: Add pre-release checklist test
+
+**Files:**
+- Modify: `tests/test_enforcement_config.py`
+
+- [ ] **Step 1: Write the test**
+
+Add to `tests/test_enforcement_config.py`:
+
+```python
+def test_pre_release_hook_validation_gate():
+    """Pre-release gate: smoke test script exists and is executable."""
+    smoke_test = Path(__file__).parent.parent / "scripts" / "smoke-test-hooks.sh"
+    assert smoke_test.exists(), "scripts/smoke-test-hooks.sh missing"
+    assert os.access(smoke_test, os.X_OK), "scripts/smoke-test-hooks.sh not executable"
+
+
+def test_hook_schema_exists():
+    """Pre-release gate: hook_schema.py must exist as source of truth."""
+    schema = Path(__file__).parent / "hook_schema.py"
+    assert schema.exists(), "tests/hook_schema.py missing — hooks have no schema to validate against"
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `python -m pytest tests/test_enforcement_config.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_enforcement_config.py
+git commit -m "feat(hooks): add pre-release gate for schema and smoke test"
+```
+
+---
+
+### Task 6: Document the release process addition
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add smoke test to the release checklist**
+
+In the "Cutting a Release" section of CLAUDE.md, add after step 3:
+
+```markdown
+4. Run hook smoke test: `scripts/smoke-test-hooks.sh --verbose`
+5. Run schema freshness check: `python -m pytest tests/test_hook_schema_freshness.py -v`
+```
+
+Renumber subsequent steps.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add hook smoke test and schema check to release checklist"
+```

--- a/enforcement/hooks-manifest.json
+++ b/enforcement/hooks-manifest.json
@@ -4,6 +4,6 @@
     "PostToolUse": ["post_tool_hook.py", "bash_guard.py", "protocol_tracker.py"],
     "UserPromptSubmit": ["primer.py"],
     "Stop": ["stop_hook.py"],
-    "SubagentStop": ["lens_quiz.py"]
+    "SubagentStop": ["lens_quiz.py", "subagent_findings_check.py"]
   }
 }

--- a/enforcement/hooks/_common.py
+++ b/enforcement/hooks/_common.py
@@ -127,7 +127,7 @@ def exit_enforcement_error(
             if hook_type == "PreToolUse":
                 exit_block(f"ENFORCEMENT DEGRADED: {reason}")
             else:
-                exit_warn(f"ENFORCEMENT DEGRADED: {reason}")
+                exit_warn(f"ENFORCEMENT DEGRADED: {reason}", hook_type)
     # No active audit or stale enforcement — fail-open
     if hook_type == "PreToolUse":
         exit_ok("PreToolUse")

--- a/enforcement/hooks/_daemon_lifecycle.py
+++ b/enforcement/hooks/_daemon_lifecycle.py
@@ -34,7 +34,7 @@ def main() -> None:
 
     data_dir = os.path.join(cwd, "docs", "holtz", ".sahjhan")
     if not os.path.isdir(data_dir):
-        exit_ok()
+        exit_ok("PreToolUse")
 
     # Already terminated — block immediately
     terminated = os.path.join(data_dir, "terminated")
@@ -48,11 +48,11 @@ def main() -> None:
     init_pid = _read_init_pid(cwd)
     if init_pid is None:
         # No init PID tracked — legacy audit or pre-init.
-        exit_ok()
+        exit_ok("PreToolUse")
 
     # Init PID exists — is it still alive?
     if _is_process_alive(init_pid):
-        exit_ok()
+        exit_ok("PreToolUse")
 
     # Init PID is dead. Audit is over.
     _write_terminated_marker(cwd, init_pid, detected_by="_daemon_lifecycle")

--- a/enforcement/hooks/_protocol_cache.py
+++ b/enforcement/hooks/_protocol_cache.py
@@ -226,9 +226,12 @@ def _split_shell_segments(cmd: str) -> list[str]:
     # Strip shell redirections: 2>&1, >&2, 2>/dev/null, etc.
     cleaned = re.sub(r'\d*>&?\d+', '', cmd)
     cleaned = re.sub(r'\d*>/dev/null', '', cleaned)
-    # Split on actual shell operators: &&, ||, ;, |
+    # Split on actual shell operators: &&, ||, ;, |, newline
     # Use specific multi-char operators first to avoid splitting on single &
-    segments = re.split(r'&&|\|\||[;|]', cleaned)
+    # Include \n: Claude Code can send newline-separated commands in a single
+    # Bash call. Without \n, commands like "echo\ngit commit" bypass detection.
+    # Must match _sahjhan_bootstrap.py's split pattern to avoid divergence.
+    segments = re.split(r'&&|\|\||[;|\n]', cleaned)
     result = []
     for seg in segments:
         seg = seg.strip()

--- a/enforcement/hooks/_sahjhan_bootstrap.py
+++ b/enforcement/hooks/_sahjhan_bootstrap.py
@@ -411,24 +411,21 @@ def main() -> None:
 
 def _allow() -> None:
     print(json.dumps({
-        "continue": True,
-        "suppressOutput": True,
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "allow",
             "permissionDecisionReason": "",
         },
+        "suppressOutput": True,
     }))
     sys.exit(0)
 
 
 def _block(reason: str) -> None:
     print(json.dumps({
-        "continue": False,
-        "suppressOutput": False,
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "block",
+            "permissionDecision": "deny",
             "permissionDecisionReason": reason,
         },
     }))

--- a/enforcement/hooks/_sahjhan_bootstrap.py
+++ b/enforcement/hooks/_sahjhan_bootstrap.py
@@ -257,9 +257,31 @@ def _check_bash_write(command: str) -> str | None:
                         "This path cannot be modified during an audit session."
                     )
 
-            # cp/mv/install check: protected path as LAST argument
-            if any(seg_cmd.startswith(c) for c in ("cp ", "mv ", "install ")):
+            # cp/mv/install check: protected path as target.
+            # Handles both standard form (target is last arg) and -t/--target-directory
+            # form where the target comes after the flag. Also handles full-path
+            # commands like /bin/cp, /usr/bin/mv by extracting the basename.
+            first_token = seg_cmd.split()[0] if seg_cmd.split() else ""
+            cmd_basename = first_token.rsplit("/", 1)[-1] if "/" in first_token else first_token
+            if any(cmd_basename == c.strip() for c in ("cp", "mv", "install")):
                 args = seg_cmd.split()
+                # Check -t / --target-directory flag (target is NOT last arg)
+                for i, arg in enumerate(args):
+                    if arg in ("-t", "--target-directory") and i + 1 < len(args):
+                        target = args[i + 1]
+                        if target == p or target.startswith(p):
+                            return (
+                                f"BLOCKED: Bash command copies/moves to protected path '{p}'. "
+                                "This path cannot be modified during an audit session."
+                            )
+                    if arg.startswith("--target-directory="):
+                        target = arg.split("=", 1)[1]
+                        if target == p or target.startswith(p):
+                            return (
+                                f"BLOCKED: Bash command copies/moves to protected path '{p}'. "
+                                "This path cannot be modified during an audit session."
+                            )
+                # Standard form: target is last argument
                 if len(args) >= 3:
                     dest = args[-1]
                     if dest == p or dest.startswith(p):
@@ -271,7 +293,8 @@ def _check_bash_write(command: str) -> str | None:
             # Issue #33: rm/rmdir check — destructive operations on protected paths
             # Also match trailing-slash-stripped form so that
             # "rm -rf docs/holtz/.sahjhan" matches "docs/holtz/.sahjhan/".
-            if any(seg_cmd.startswith(c) for c in ("rm ", "rm\t", "rmdir ")):
+            # Handle full-path commands (/bin/rm, /usr/bin/rmdir).
+            if cmd_basename in ("rm", "rmdir"):
                 p_stripped = p.rstrip("/")
                 ref = _segment_references_protected(seg, [p, p_stripped])
                 if ref:

--- a/enforcement/hooks/bash_guard.py
+++ b/enforcement/hooks/bash_guard.py
@@ -93,7 +93,8 @@ def main() -> None:
         exit_warn(
             f"PROTOCOL VIOLATION: Managed file integrity check failed. "
             f"Detail: {detail}. This violation is permanent and will "
-            f"block convergence for this run."
+            f"block convergence for this run.",
+            "PostToolUse",
         )
 
     exit_ok()

--- a/enforcement/hooks/bash_guard.py
+++ b/enforcement/hooks/bash_guard.py
@@ -14,9 +14,6 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from _protocol_cache import is_enforcement_fresh, is_sahjhan_cmd, read_cache  # noqa: E402
-from _resolve import ensure_sahjhan  # noqa: E402
-
 from _common import (  # noqa: E402
     exit_enforcement_error,
     exit_ok,
@@ -24,6 +21,8 @@ from _common import (  # noqa: E402
     read_event,
     resolve_config_dir,
 )
+from _protocol_cache import is_enforcement_fresh, is_sahjhan_cmd, read_cache  # noqa: E402
+from _resolve import ensure_sahjhan  # noqa: E402
 
 
 def main() -> None:

--- a/enforcement/hooks/commit_gate.py
+++ b/enforcement/hooks/commit_gate.py
@@ -100,7 +100,7 @@ def main() -> None:
 
     # Soft injection: obligations exist but don't block this command
     if injection:
-        exit_warn(injection)
+        exit_warn(injection, "PreToolUse")
 
     exit_ok("PreToolUse")
 

--- a/enforcement/hooks/commit_gate.py
+++ b/enforcement/hooks/commit_gate.py
@@ -30,11 +30,11 @@ from _common import exit_block, exit_ok, exit_warn, read_event  # noqa: E402
 def _is_test_cmd(cmd: str) -> bool:
     """Detect test/pytest commands that should always be allowed.
 
-    Checks each segment of chained commands (split on &&, ||, ;, |)
+    Checks each segment of chained commands (split on &&, ||, ;, |, newline)
     so that ``cd /project && pytest`` is recognized.
     """
     import re as _re
-    for segment in _re.split(r'&&|\|\||[;|]', cmd):
+    for segment in _re.split(r'&&|\|\||[;|\n]', cmd):
         seg = segment.strip()
         if seg.startswith("pytest") or seg.startswith("python -m pytest"):
             return True

--- a/enforcement/hooks/commit_gate.py
+++ b/enforcement/hooks/commit_gate.py
@@ -14,6 +14,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
+from _common import exit_block, exit_ok, exit_warn, read_event  # noqa: E402
 from _protocol_cache import (  # noqa: E402
     compute_obligations,
     format_injection,
@@ -23,8 +24,6 @@ from _protocol_cache import (  # noqa: E402
     is_sahjhan_cmd,
     read_cache,
 )
-
-from _common import exit_block, exit_ok, exit_warn, read_event  # noqa: E402
 
 
 def _is_test_cmd(cmd: str) -> bool:

--- a/enforcement/hooks/lens_quiz.py
+++ b/enforcement/hooks/lens_quiz.py
@@ -20,13 +20,6 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from _resolve import ensure_sahjhan  # noqa: E402
-from lens_evidence import (  # noqa: E402
-    check_artifact,
-    check_transcript,
-    parse_transcript_jsonl,
-)
-
 from _common import (  # noqa: E402
     _daemon_request,
     _get_daemon_socket_path,
@@ -36,6 +29,12 @@ from _common import (  # noqa: E402
     read_event,
     record_authed_event,
     resolve_config_dir,
+)
+from _resolve import ensure_sahjhan  # noqa: E402
+from lens_evidence import (  # noqa: E402
+    check_artifact,
+    check_transcript,
+    parse_transcript_jsonl,
 )
 
 # ── Vault helpers ──

--- a/enforcement/hooks/lens_quiz.py
+++ b/enforcement/hooks/lens_quiz.py
@@ -412,8 +412,14 @@ def main() -> None:
         events_list = [{"type": "assistant", "content": message}]
 
     # Load quiz bank from daemon vault (secrets never on disk)
+    # Graceful degradation: catch daemon-unavailable errors (OSError covers
+    # socket failures; RuntimeError covers daemon-returned errors; KeyError
+    # covers missing "data" field when vault is unpopulated).
+    # Data corruption (binascii.Error, json.JSONDecodeError) is NOT caught —
+    # corrupt vault data should crash the hook visibly, not silently disable
+    # the quiz gate.
     bank: list[dict] = []
-    with contextlib.suppress(Exception):
+    with contextlib.suppress(OSError, RuntimeError, KeyError):
         import base64
         sock_path = _get_daemon_socket_path(cwd)
         resp = _daemon_request(sock_path, {"op": "vault_read", "name": "quiz-bank"})

--- a/enforcement/hooks/post_tool_hook.py
+++ b/enforcement/hooks/post_tool_hook.py
@@ -163,7 +163,7 @@ def main() -> None:
         warnings = [m["message"] for m in messages if m.get("action") == "warn"]
         warnings.extend(w["message"] for w in monitor_warnings)
         if warnings:
-            exit_warn(" | ".join(warnings))
+            exit_warn(" | ".join(warnings), "PostToolUse")
 
     exit_ok()
 

--- a/enforcement/hooks/post_tool_hook.py
+++ b/enforcement/hooks/post_tool_hook.py
@@ -23,9 +23,6 @@ from typing import Any
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from _protocol_cache import is_enforcement_fresh, read_cache  # noqa: E402
-from _resolve import ensure_sahjhan  # noqa: E402
-
 from _common import (  # noqa: E402
     exit_enforcement_error,
     exit_ok,
@@ -33,6 +30,8 @@ from _common import (  # noqa: E402
     read_event,
     resolve_config_dir,
 )
+from _protocol_cache import is_enforcement_fresh, read_cache  # noqa: E402
+from _resolve import ensure_sahjhan  # noqa: E402
 
 
 def _enrich_auto_record(

--- a/enforcement/hooks/pre_tool_hook.py
+++ b/enforcement/hooks/pre_tool_hook.py
@@ -99,7 +99,7 @@ def main() -> None:
         monitor_warnings = eval_data.get("monitor_warnings", [])
         warnings.extend(w["message"] for w in monitor_warnings)
         if warnings:
-            exit_warn(" | ".join(warnings))
+            exit_warn(" | ".join(warnings), "PreToolUse")
 
     exit_ok("PreToolUse")
 

--- a/enforcement/hooks/pre_tool_hook.py
+++ b/enforcement/hooks/pre_tool_hook.py
@@ -18,11 +18,10 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
+from _common import exit_block, exit_enforcement_error, exit_ok, exit_warn, read_event, resolve_config_dir  # noqa: E402
 from _protocol_cache import is_enforcement_fresh, read_cache  # noqa: E402
 from _resolve import ensure_sahjhan  # noqa: E402
 from _sahjhan_bootstrap import MANAGED_DOCS  # noqa: E402
-
-from _common import exit_block, exit_enforcement_error, exit_ok, exit_warn, read_event, resolve_config_dir  # noqa: E402
 
 
 def main() -> None:

--- a/enforcement/hooks/primer.py
+++ b/enforcement/hooks/primer.py
@@ -55,7 +55,8 @@ def main() -> None:
         exit_warn(
             "AUDIT TERMINATED: daemon died — session key lost. "
             "The ledger is unwritable. This audit cannot be completed. "
-            "Use /stop to exit, then start a new audit."
+            "Use /stop to exit, then start a new audit.",
+            "UserPromptSubmit",
         )
 
     # Get current status
@@ -117,7 +118,8 @@ def main() -> None:
         exit_warn(
             "AUDIT TERMINATED: daemon died during awaiting_clear — session key lost. "
             "The ledger is unwritable. This audit cannot be completed. "
-            "Use /stop to exit, then start a new audit."
+            "Use /stop to exit, then start a new audit.",
+            "UserPromptSubmit",
         )
 
     # Build resume context
@@ -162,7 +164,7 @@ def main() -> None:
     if run_number != "0":
         context += f"\nActive ledger: run-{run_number}"
 
-    exit_warn(context)
+    exit_warn(context, "UserPromptSubmit")
 
 
 if __name__ == "__main__":

--- a/enforcement/hooks/primer.py
+++ b/enforcement/hooks/primer.py
@@ -18,10 +18,6 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from _protocol_cache import format_state_line, parse_status_text  # noqa: E402
-from _protocol_cache import read_cache as read_enforcement_cache
-from _resolve import ensure_sahjhan  # noqa: E402
-
 from _common import (  # noqa: E402
     _is_process_alive,
     _read_init_pid,
@@ -32,6 +28,9 @@ from _common import (  # noqa: E402
     record_authed_event,
     resolve_config_dir,
 )
+from _protocol_cache import format_state_line, parse_status_text  # noqa: E402
+from _protocol_cache import read_cache as read_enforcement_cache
+from _resolve import ensure_sahjhan  # noqa: E402
 
 
 def main() -> None:

--- a/enforcement/hooks/protocol_tracker.py
+++ b/enforcement/hooks/protocol_tracker.py
@@ -33,11 +33,11 @@ from _common import exit_ok, read_event, resolve_config_dir  # noqa: E402
 def _is_tdd_cmd(cmd: str) -> bool:
     """Detect test, lint, and type-check commands (TDD workflow).
 
-    Checks each segment of chained commands (split on &&, ||, ;, |)
+    Checks each segment of chained commands (split on &&, ||, ;, |, newline)
     so that ``cd /project && python -m pytest`` is recognized.
     """
     _TDD_PREFIXES = ("pytest", "python -m pytest", "ruff check", "ruff format", "mypy")
-    for segment in re.split(r'&&|\|\||[;|]', cmd):
+    for segment in re.split(r'&&|\|\||[;|\n]', cmd):
         seg = segment.strip()
         if any(seg.startswith(p) for p in _TDD_PREFIXES):
             return True
@@ -49,10 +49,10 @@ def _is_sleep_cmd(cmd: str) -> bool:
 
     Returns True for sleep >5 seconds. Short sleeps (<=5s) are allowed
     for legitimate polling. Checks each segment of chained commands
-    (split on &&, ;, ||, |). Handles bash sleep suffixes (s/m/h/d).
+    (split on &&, ;, ||, |, newline). Handles bash sleep suffixes (s/m/h/d).
     """
     _SUFFIX_MULTIPLIER = {"s": 1, "m": 60, "h": 3600, "d": 86400}
-    for segment in re.split(r'[;&|]+', cmd):
+    for segment in re.split(r'[;&|\n]+', cmd):
         m = re.match(r"^\s*sleep\s+(\d+(?:\.\d+)?)([smhd])?", segment)
         if m:
             value = float(m.group(1))

--- a/enforcement/hooks/protocol_tracker.py
+++ b/enforcement/hooks/protocol_tracker.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.dirname(__file__))
 
+from _common import exit_ok, read_event, resolve_config_dir  # noqa: E402
 from _protocol_cache import (  # noqa: E402
     empty_cache,
     is_enforcement_fresh,
@@ -26,8 +27,6 @@ from _protocol_cache import (  # noqa: E402
     write_cache,
 )
 from _resolve import ensure_sahjhan  # noqa: E402
-
-from _common import exit_ok, read_event, resolve_config_dir  # noqa: E402
 
 
 def _is_tdd_cmd(cmd: str) -> bool:

--- a/enforcement/hooks/stop_hook.py
+++ b/enforcement/hooks/stop_hook.py
@@ -21,9 +21,6 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from _protocol_cache import is_enforcement_fresh, read_cache  # noqa: E402
-from _resolve import ensure_sahjhan  # noqa: E402
-
 from _common import (  # noqa: E402
     _is_process_alive,
     _read_init_pid,
@@ -34,6 +31,8 @@ from _common import (  # noqa: E402
     read_event,
     resolve_config_dir,
 )
+from _protocol_cache import is_enforcement_fresh, read_cache  # noqa: E402
+from _resolve import ensure_sahjhan  # noqa: E402
 
 # Two sets because "allowed to stop" ≠ "safe to kill daemon".
 # awaiting_clear allows stop (the turn is done) but the daemon must

--- a/enforcement/hooks/stop_hook.py
+++ b/enforcement/hooks/stop_hook.py
@@ -144,9 +144,12 @@ def main() -> None:
         exit_stop_allow()
 
     # Non-terminal state: check freshness
+    # Note: _DAEMON_CLEANUP_STATES is a subset of _STOP_ALLOWED_STATES,
+    # so if we reach here (state not in _STOP_ALLOWED_STATES), the state
+    # is never in _DAEMON_CLEANUP_STATES. No daemon cleanup needed —
+    # this is a stale non-terminal audit, and the daemon may still hold
+    # a session key for a potential resume.
     if not is_enforcement_fresh(cache):
-        if current_state in _DAEMON_CLEANUP_STATES:
-            _try_stop_daemon(cwd)
         exit_stop_warn(
             f"Stale Holtz audit detected (state: '{current_state}'). "
             "No recent sahjhan activity — this appears to be an abandoned audit. "

--- a/enforcement/quiz-bank.json
+++ b/enforcement/quiz-bank.json
@@ -171,7 +171,7 @@
   },
   {
     "lens": "security",
-    "q": "write_guard.py resolves paths using what function to prevent traversal?",
+    "q": "_sahjhan_bootstrap.py resolves paths using what function to prevent traversal?",
     "a": "B",
     "opts": [
       "os.path.abspath",
@@ -179,16 +179,16 @@
       "pathlib.Path.resolve",
       "os.path.normpath"
     ],
-    "source": "enforcement/hooks/write_guard.py::main",
+    "source": "enforcement/hooks/_sahjhan_bootstrap.py::main",
     "keywords": [
-      "write_guard",
+      "_sahjhan_bootstrap",
       "realpath",
       "path traversal"
     ]
   },
   {
     "lens": "security",
-    "q": "How many files are in MANAGED_FILES in write_guard.py?",
+    "q": "How many files are in MANAGED_DOCS in _sahjhan_bootstrap.py?",
     "a": "C",
     "opts": [
       "3",
@@ -196,10 +196,10 @@
       "5",
       "6"
     ],
-    "source": "enforcement/hooks/write_guard.py::MANAGED_FILES",
+    "source": "enforcement/hooks/_sahjhan_bootstrap.py::MANAGED_DOCS",
     "keywords": [
-      "MANAGED_FILES",
-      "write_guard",
+      "MANAGED_DOCS",
+      "_sahjhan_bootstrap",
       "managed"
     ]
   },
@@ -290,19 +290,19 @@
   },
   {
     "lens": "error-propagation",
-    "q": "stop_gate.py allows stop on subprocess.TimeoutExpired via what pattern?",
-    "a": "B",
+    "q": "stop_hook.py handles TimeoutExpired in _try_stop_daemon via what pattern?",
+    "a": "C",
     "opts": [
       "try/except pass",
       "try/except exit_stop_allow()",
       "contextlib.suppress",
       "result.returncode check"
     ],
-    "source": "enforcement/hooks/stop_gate.py::main",
+    "source": "enforcement/hooks/stop_hook.py::_try_stop_daemon",
     "keywords": [
-      "stop_gate",
+      "stop_hook",
       "TimeoutExpired",
-      "exit_stop_allow"
+      "contextlib.suppress"
     ]
   },
   {

--- a/git-hooks/post-commit
+++ b/git-hooks/post-commit
@@ -6,6 +6,14 @@ set -euo pipefail
 
 PLUGIN_JSON=".claude-plugin/plugin.json"
 
+# Guard against double-bump: if plugin.json was already modified in this
+# commit (e.g., by the commit-msg hook), skip the post-commit bump.
+# Without this, install-hooks.sh (which installs both hooks) would cause
+# every feat/fix/perf commit to bump the version twice.
+if git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null | grep -qF "$PLUGIN_JSON"; then
+    exit 0
+fi
+
 # Read the just-created commit
 FIRST_LINE=$(git log -1 --pretty=%s)
 BODY=$(git log -1 --pretty=%b)

--- a/hooks/_common.py
+++ b/hooks/_common.py
@@ -3,17 +3,21 @@
 All hooks read JSON from stdin and write modern-format JSON to stdout.
 Every hook exits 0. The JSON payload controls the decision:
 
-  PreToolUse/PostToolUse/UserPromptSubmit:
-  - exit_ok:    {"continue": true,  "suppressOutput": true, ...}
-  - exit_warn:  {"continue": true,  "suppressOutput": false, "additionalContext": msg}
-  - exit_block: {"continue": false, "suppressOutput": false, "hookSpecificOutput": {...}}
+  PreToolUse:
+  - exit_ok:    hookSpecificOutput with permissionDecision "allow"
+  - exit_warn:  hookSpecificOutput with permissionDecision "allow" + additionalContext
+  - exit_block: hookSpecificOutput with permissionDecision "deny"
 
-  Stop:
+  PostToolUse/UserPromptSubmit:
+  - exit_ok:    {"continue": true,  "suppressOutput": true}
+  - exit_warn:  {"continue": true,  "suppressOutput": false, "systemMessage": msg}
+
+  Stop/SubagentStop:
   - exit_stop_allow:  (no output, exit 0)
+  - exit_stop_warn:   {"systemMessage": msg}  (allows stop, shows msg to user)
   - exit_stop_block:  {"decision": "block", "reason": msg}
 
-PreToolUse hooks include hookSpecificOutput with permissionDecision.
-See: https://github.com/anthropics/claude-code/issues/17088
+See: https://code.claude.com/docs/en/hooks
 """
 from __future__ import annotations
 
@@ -39,46 +43,81 @@ def read_event() -> dict[str, Any]:
 
 
 def exit_ok(event_name: str = "") -> None:
-    """Allow the tool call. Modern JSON on stdout, exit 0.
+    """Allow the tool call silently, exit 0.
 
-    For PreToolUse hooks, pass event_name="PreToolUse" to include
-    hookSpecificOutput with permissionDecision (avoids phantom
-    "hook error" label in the Claude Code UI).
+    For PreToolUse hooks, pass event_name="PreToolUse" to emit
+    hookSpecificOutput with permissionDecision "allow".
+    Other events get universal top-level fields only.
+
+    See: https://code.claude.com/docs/en/hooks
     """
-    output: dict[str, Any] = {"continue": True, "suppressOutput": True}
     if event_name == "PreToolUse":
-        output["hookSpecificOutput"] = {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "allow",
-            "permissionDecisionReason": "",
-        }
-    print(json.dumps(output))
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+                "permissionDecisionReason": "",
+            },
+            "suppressOutput": True,
+        }))
+    else:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
     sys.exit(0)
 
 
-def exit_warn(msg: str) -> None:
-    """Warn but allow. Modern JSON on stdout, exit 0."""
-    print(json.dumps({
-        "continue": True,
-        "suppressOutput": False,
-        "additionalContext": msg,
-    }))
+def exit_warn(msg: str, event_name: str = "") -> None:
+    """Warn but allow, exit 0.
+
+    When event_name is provided, emits hookSpecificOutput with
+    additionalContext (shown to Claude). PreToolUse additionally
+    requires permissionDecision.
+
+    Without event_name: uses universal systemMessage (shown to user).
+
+    See: https://code.claude.com/docs/en/hooks
+    """
+    if event_name == "PreToolUse":
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+                "permissionDecisionReason": "",
+                "additionalContext": msg,
+            },
+        }))
+    elif event_name:
+        # PostToolUse, UserPromptSubmit, etc. — hookSpecificOutput
+        # with additionalContext injects context to Claude
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": event_name,
+                "additionalContext": msg,
+            },
+        }))
+    else:
+        print(json.dumps({
+            "continue": True,
+            "suppressOutput": False,
+            "systemMessage": msg,
+        }))
     sys.exit(0)
 
 
 def exit_block(msg: str) -> None:
-    """Block the tool call. Modern JSON on stdout, exit 0.
+    """Block the tool call (PreToolUse only), exit 0.
 
-    For PreToolUse hooks only — uses hookSpecificOutput with
-    permissionDecision "block". PostToolUse hooks should use
-    exit_warn() instead since the tool has already executed.
+    Emits hookSpecificOutput with permissionDecision "deny".
+    The reason is shown to Claude so it can adapt.
+
+    Valid permissionDecision values: "allow", "deny", "ask", "defer".
+    Do NOT use "continue": false — that stops Claude entirely.
+
+    See: https://code.claude.com/docs/en/hooks
     """
     print(json.dumps({
-        "continue": False,
-        "suppressOutput": False,
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "block",
+            "permissionDecision": "deny",
             "permissionDecisionReason": msg,
         },
     }))
@@ -156,13 +195,14 @@ def exit_stop_warn(message: str) -> None:
     """Allow a Stop event but surface a warning message.
 
     Used when enforcement is degraded (e.g., config not found) — the
-    stop proceeds but the agent sees the warning. Uses decision="approve"
-    (the schema-valid allow value) so Claude Code shows the message
-    (hasOutput=true) without blocking continuation.
+    stop proceeds but the user sees the warning. Uses the universal
+    systemMessage field (shown to user). Stop hooks only support
+    decision="block"; omit decision to allow.
+
+    See: https://code.claude.com/docs/en/hooks
     """
     print(json.dumps({
-        "decision": "approve",
-        "reason": message,
+        "systemMessage": message,
     }))
     sys.exit(0)
 

--- a/hooks/subagent_findings_check.py
+++ b/hooks/subagent_findings_check.py
@@ -13,7 +13,7 @@ and false positives are preferable to missed findings.
 
 Output format: SubagentStop uses the Stop protocol:
 - Allow: no output (exit 0)
-- Warn: {"decision": "approve", "reason": msg}
+- Warn: {"systemMessage": msg}  (allows stop, shows msg to user)
 - Block: {"decision": "block", "reason": msg}
 """
 from __future__ import annotations

--- a/hooks/subagent_findings_check.py
+++ b/hooks/subagent_findings_check.py
@@ -35,7 +35,7 @@ def main() -> None:
         exit_stop_allow()
 
     # Scan for docs/holtz/ file references (.md, .json, .jsonl, .toml, .txt)
-    paths = re.findall(r'docs/holtz/[^\s"\')\]]+\.(?:md|json|jsonl|toml|txt)', message)
+    paths = re.findall(r'docs/holtz/[^\s"\')\],;]+\.(?:md|json|jsonl|toml|txt)', message)
     if not paths:
         exit_stop_allow()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 target-version = "py312"
 line-length = 120
-src = ["skills/holtz/scripts", "tests", "hooks"]
+src = ["skills/holtz/scripts", "tests", "hooks", "enforcement/hooks"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM", "ANN"]
@@ -12,7 +12,7 @@ select = ["E", "F", "W", "I", "UP", "B", "SIM", "ANN"]
 
 [tool.mypy]
 python_version = "3.12"
-files = ["skills/holtz/scripts", "hooks"]
+files = ["skills/holtz/scripts", "hooks", "enforcement/hooks"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/scripts/generate-changelog.py
+++ b/scripts/generate-changelog.py
@@ -104,6 +104,7 @@ def format_changelog(commits: list[dict], version: str, since: str | None) -> st
             continue
         if c["breaking"]:
             breaking.append(f"- **BREAKING:** {c['desc']}")
+            continue  # don't double-count in normal section
 
         section = SECTION_MAP.get(c["type"], "Other")
         scope = f"**{c['scope']}:** " if c["scope"] else ""

--- a/scripts/smoke-test-hooks.sh
+++ b/scripts/smoke-test-hooks.sh
@@ -43,10 +43,10 @@ HOOK_EVENTS["enforcement/hooks/stop_hook.py"]="Stop"
 HOOK_EVENTS["enforcement/hooks/primer.py"]="UserPromptSubmit"
 HOOK_EVENTS["hooks/subagent_findings_check.py"]="SubagentStop"
 
+SKIPPED=0
 for hook_path in "${!HOOK_EVENTS[@]}"; do
     event="${HOOK_EVENTS[$hook_path]}"
     hook_name=$(basename "$hook_path" .py)
-    TESTED=$((TESTED + 1))
 
     # Build a settings.json that registers just this one hook
     # Use the appropriate matcher for the event type
@@ -66,8 +66,11 @@ for hook_path in "${!HOOK_EVENTS[@]}"; do
     elif [[ "$event" == "SubagentStop" ]]; then
         # SubagentStop is hard to trigger in isolation — skip live test
         echo "SKIP $hook_name ($event — requires subagent)"
+        SKIPPED=$((SKIPPED + 1))
         continue
     fi
+
+    TESTED=$((TESTED + 1))
 
     # Write temp settings
     mkdir -p "$WORK_DIR/.claude"
@@ -105,7 +108,7 @@ SETTINGS_EOF
 done
 
 echo ""
-echo "Results: $((TESTED - FAILURES))/$TESTED passed"
+echo "Results: $((TESTED - FAILURES))/$TESTED passed ($SKIPPED skipped)"
 if [[ $FAILURES -gt 0 ]]; then
     echo "FAILED: $FAILURES hook(s) produced invalid JSON"
     exit 1

--- a/scripts/smoke-test-hooks.sh
+++ b/scripts/smoke-test-hooks.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scripts/smoke-test-hooks.sh
+#
+# Live smoke test: registers each hook against real Claude Code
+# and verifies no "validation failed" or "hook error" in output.
+#
+# Requires: claude CLI in PATH
+# Usage: scripts/smoke-test-hooks.sh [--verbose]
+#
+# Exit 0 = all hooks valid, Exit 1 = at least one failed
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERBOSE="${1:-}"
+FAILURES=0
+TESTED=0
+
+# Temp dir for isolated settings
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Create minimal project structure
+mkdir -p "$WORK_DIR/src"
+echo "print('hello')" > "$WORK_DIR/src/app.py"
+
+# Check claude is available
+if ! command -v claude &>/dev/null; then
+    echo "SKIP: claude CLI not in PATH"
+    exit 0
+fi
+
+# Map each hook to its event type and a trigger prompt
+declare -A HOOK_EVENTS
+HOOK_EVENTS["enforcement/hooks/_daemon_lifecycle.py"]="PreToolUse"
+HOOK_EVENTS["enforcement/hooks/_sahjhan_bootstrap.py"]="PreToolUse"
+HOOK_EVENTS["enforcement/hooks/pre_tool_hook.py"]="PreToolUse"
+HOOK_EVENTS["enforcement/hooks/commit_gate.py"]="PreToolUse"
+HOOK_EVENTS["enforcement/hooks/post_tool_hook.py"]="PostToolUse"
+HOOK_EVENTS["enforcement/hooks/bash_guard.py"]="PostToolUse"
+HOOK_EVENTS["enforcement/hooks/protocol_tracker.py"]="PostToolUse"
+HOOK_EVENTS["enforcement/hooks/stop_hook.py"]="Stop"
+HOOK_EVENTS["enforcement/hooks/primer.py"]="UserPromptSubmit"
+HOOK_EVENTS["hooks/subagent_findings_check.py"]="SubagentStop"
+
+for hook_path in "${!HOOK_EVENTS[@]}"; do
+    event="${HOOK_EVENTS[$hook_path]}"
+    hook_name=$(basename "$hook_path" .py)
+    TESTED=$((TESTED + 1))
+
+    # Build a settings.json that registers just this one hook
+    # Use the appropriate matcher for the event type
+    if [[ "$event" == "PreToolUse" ]]; then
+        MATCHER="Bash"
+        PROMPT="run echo smoke-test-$hook_name"
+    elif [[ "$event" == "PostToolUse" ]]; then
+        MATCHER="Bash"
+        PROMPT="run echo smoke-test-$hook_name"
+    elif [[ "$event" == "Stop" ]]; then
+        # Stop hooks fire when Claude tries to stop — use a one-shot prompt
+        MATCHER="*"
+        PROMPT="say hi"
+    elif [[ "$event" == "UserPromptSubmit" ]]; then
+        MATCHER="*"
+        PROMPT="say hi"
+    elif [[ "$event" == "SubagentStop" ]]; then
+        # SubagentStop is hard to trigger in isolation — skip live test
+        echo "SKIP $hook_name ($event — requires subagent)"
+        continue
+    fi
+
+    # Write temp settings
+    mkdir -p "$WORK_DIR/.claude"
+    cat > "$WORK_DIR/.claude/settings.local.json" <<SETTINGS_EOF
+{
+    "hooks": {
+        "$event": [
+            {
+                "matcher": "$MATCHER",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python \"$REPO_ROOT/$hook_path\""
+                    }
+                ]
+            }
+        ]
+    }
+}
+SETTINGS_EOF
+
+    # Run claude with the hook active
+    OUTPUT=$(cd "$WORK_DIR" && claude -p "$PROMPT" --no-input 2>&1) || true
+
+    # Check for validation failures
+    if echo "$OUTPUT" | grep -qi "json.*validation.*failed\|hook.*error.*validation"; then
+        echo "FAIL $hook_name ($event): json validation failed"
+        if [[ "$VERBOSE" == "--verbose" ]]; then
+            echo "  Output: ${OUTPUT:0:500}"
+        fi
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS $hook_name ($event)"
+    fi
+done
+
+echo ""
+echo "Results: $((TESTED - FAILURES))/$TESTED passed"
+if [[ $FAILURES -gt 0 ]]; then
+    echo "FAILED: $FAILURES hook(s) produced invalid JSON"
+    exit 1
+fi
+echo "All hooks produce valid JSON per Claude Code"
+exit 0

--- a/scripts/token_profiler/viewer.py
+++ b/scripts/token_profiler/viewer.py
@@ -17,6 +17,8 @@ def generate_html(profile: RunProfile) -> str:
     template = TEMPLATE_PATH.read_text()
     data = asdict(profile)
     profile_json = json.dumps(data, default=str)  # str handles datetimes
+    # Escape </script> to prevent XSS when embedding in <script> tags
+    profile_json = profile_json.replace("</", r"<\/")
     return template.replace(
         DATA_PLACEHOLDER, f"const PROFILE_DATA = {profile_json};"
     )

--- a/scripts/vendor-sahjhan.sh
+++ b/scripts/vendor-sahjhan.sh
@@ -10,7 +10,7 @@ mkdir -p "$BIN_DIR"
 
 for target in aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
     echo "Downloading sahjhan-${target}..."
-    curl -sL "${BASE_URL}/sahjhan-${target}" -o "${BIN_DIR}/sahjhan-${target}"
+    curl -sfL "${BASE_URL}/sahjhan-${target}" -o "${BIN_DIR}/sahjhan-${target}"
     chmod +x "${BIN_DIR}/sahjhan-${target}"
 done
 

--- a/skills/holtz/scripts/impact_graph.py
+++ b/skills/holtz/scripts/impact_graph.py
@@ -169,7 +169,7 @@ class ImpactGraph:
         """Direct outgoing neighbors, optionally filtered by edge type."""
         if node_id not in self.nodes:
             return []
-        type_set = set(types) if types else None
+        type_set = set(types) if types is not None else None
         result: set[str] = set()
         for edge in self.edges:
             if edge["source"] == node_id and (type_set is None or edge["type"] in type_set):
@@ -185,7 +185,7 @@ class ImpactGraph:
         if node_id not in self.nodes or depth <= 0:
             return []
 
-        type_set = set(types) if types else None
+        type_set = set(types) if types is not None else None
         visited: set[str] = {node_id}
         result: set[str] = set()
 

--- a/skills/holtz/scripts/parse_lens_registry.py
+++ b/skills/holtz/scripts/parse_lens_registry.py
@@ -88,8 +88,9 @@ def _validate_and_append(lens: dict, lenses: list[dict]) -> None:
     if not present:
         return  # Header-only section (like the intro paragraph)
 
-    # Only validate lenses that have at least some fields
-    if present & REQUIRED_FIELDS:
+    # Only validate sections that look like a real lens (have at least 2 required fields).
+    # A non-lens section that happens to contain **Focus:** shouldn't crash the parser.
+    if len(present & REQUIRED_FIELDS) >= 2:
         if "scope" not in lens:
             raise ValueError(
                 f"Lens '{lens.get('name', '?')}' is missing required Scope field"

--- a/skills/holtz/scripts/pattern_brief_compact.py
+++ b/skills/holtz/scripts/pattern_brief_compact.py
@@ -69,8 +69,10 @@ def parse_brief(content: str) -> list[PatternEntry]:
         block = '\n'.join(original_lines[start_line:end_line])
 
         def _extract(field: str, _block: str = block) -> str:
+            # Only terminate at known field headers (**Name:**) not arbitrary bold,
+            # so field values containing **emphasis** aren't truncated.
             m = re.search(
-                rf'\*\*{field}:\*\*[ \t]*(.*?)(?=\n\*\*|\n##|\Z)',
+                rf'\*\*{field}:\*\*[ \t]*(.*?)(?=\n\*\*\w[^*]*:\*\*|\n##|\Z)',
                 _block,
                 re.DOTALL,
             )
@@ -104,13 +106,18 @@ def _compress_heuristic(heuristic: str) -> str:
         m = re.search(r'`([^`]+)`', heuristic)
         if m:
             return m.group(0)
-    first_sentence = heuristic.split('.')[0].strip()
+    # Split on sentence-ending period (followed by space or end) not mid-word dots
+    m = re.match(r'(.*?\w\.)\s', heuristic)
+    first_sentence = m.group(1) if m else heuristic.split('\n')[0].strip()
     return _truncate(first_sentence, 120)
 
 
 def _compress_example(example: str) -> str:
     """Compress an example to a single sentence."""
-    first_sentence = example.split('.')[0].strip()
+    # Split on sentence-ending period (followed by space or end) not mid-word dots
+    # like config.json, os.path, etc.
+    m = re.match(r'(.*?\w\.)\s', example)
+    first_sentence = m.group(1) if m else example.split('\n')[0].strip()
     if first_sentence.startswith('A ') or first_sentence.startswith('The '):
         first_sentence = first_sentence[0].lower() + first_sentence[1:]
     return _truncate(first_sentence, 100)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,10 @@ from pathlib import Path
 
 import pytest
 
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "network: tests that require network access")
+
 # Add scripts directory to path so we can import the modules
 sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "holtz" / "scripts"))
 # Add token_profiler package parent so `import token_profiler` works everywhere

--- a/tests/hook_schema.py
+++ b/tests/hook_schema.py
@@ -1,0 +1,159 @@
+"""Claude Code hook output schema — single source of truth.
+
+Derived from: https://code.claude.com/docs/en/hooks
+Last verified: 2026-04-11
+
+ALL test validators and assertions must reference this file.
+When Claude Code changes their spec, update THIS file only.
+"""
+from __future__ import annotations
+
+# ── PreToolUse ──────────────────────────────────────────────
+# hookSpecificOutput.permissionDecision valid values.
+# "block" is the OLD deprecated value — do NOT use it.
+PRETOOLUSE_VALID_DECISIONS: set[str] = {"allow", "deny", "ask", "defer"}
+
+# hookSpecificOutput fields for PreToolUse
+PRETOOLUSE_HSO_FIELDS: set[str] = {
+    "hookEventName",          # Required, literal "PreToolUse"
+    "permissionDecision",     # Required, one of PRETOOLUSE_VALID_DECISIONS
+    "permissionDecisionReason",  # Optional
+    "updatedInput",           # Optional
+    "additionalContext",      # Optional
+}
+
+# ── PostToolUse ─────────────────────────────────────────────
+# Top-level decision field (only "block" is valid, omit to allow)
+POSTTOOLUSE_VALID_DECISIONS: set[str] = {"block"}
+
+# hookSpecificOutput fields for PostToolUse
+POSTTOOLUSE_HSO_FIELDS: set[str] = {
+    "hookEventName",          # Required if hookSpecificOutput present
+    "additionalContext",      # Optional
+    "updatedMCPToolOutput",   # Optional
+}
+
+# ── Stop / SubagentStop ────────────────────────────────────
+# Only "block" is valid. Omit decision to allow.
+STOP_VALID_DECISIONS: set[str] = {"block"}
+
+# ── UserPromptSubmit ────────────────────────────────────────
+USERPROMPTSUBMIT_VALID_DECISIONS: set[str] = {"block"}
+
+USERPROMPTSUBMIT_HSO_FIELDS: set[str] = {
+    "hookEventName",
+    "additionalContext",
+    "sessionTitle",
+}
+
+# ── Universal top-level fields (all events) ─────────────────
+UNIVERSAL_FIELDS: set[str] = {
+    "continue",         # bool, default true. false = stop Claude entirely
+    "stopReason",       # str, shown to user when continue=false
+    "suppressOutput",   # bool, default false
+    "systemMessage",    # str, shown to user
+}
+
+# ── Spec URL (for automated freshness checks) ──────────────
+SPEC_URL = "https://code.claude.com/docs/en/hooks"
+
+
+def validate_hook_output(event_type: str, output: dict) -> list[str]:
+    """Validate hook JSON output against Claude Code's schema.
+
+    Returns a list of error strings. Empty list = valid.
+    """
+    errors: list[str] = []
+
+    if not output:
+        return errors  # Empty output is valid for all events
+
+    if event_type == "PreToolUse":
+        errors.extend(_validate_pretooluse(output))
+    elif event_type == "PostToolUse":
+        errors.extend(_validate_posttooluse(output))
+    elif event_type in ("Stop", "SubagentStop"):
+        errors.extend(_validate_stop(output))
+    elif event_type == "UserPromptSubmit":
+        errors.extend(_validate_user_prompt_submit(output))
+
+    return errors
+
+
+def _validate_pretooluse(output: dict) -> list[str]:
+    errors: list[str] = []
+    hso = output.get("hookSpecificOutput", {})
+
+    if hso:
+        if hso.get("hookEventName") != "PreToolUse":
+            errors.append(
+                f"hookEventName must be 'PreToolUse', got '{hso.get('hookEventName')}'"
+            )
+        decision = hso.get("permissionDecision")
+        if decision not in PRETOOLUSE_VALID_DECISIONS:
+            errors.append(
+                f"Invalid permissionDecision '{decision}'. "
+                f"Valid: {PRETOOLUSE_VALID_DECISIONS}"
+            )
+    else:
+        # No hookSpecificOutput — check for misplaced fields
+        bad = {"permissionDecision", "additionalContext"} & set(output.keys())
+        if bad:
+            errors.append(f"Fields {bad} must be inside hookSpecificOutput")
+
+    # continue=false + deny is a contradiction
+    if output.get("continue") is False and hso.get("permissionDecision") == "deny":
+        errors.append(
+            "continue=false stops Claude entirely — don't combine with deny"
+        )
+
+    return errors
+
+
+def _validate_posttooluse(output: dict) -> list[str]:
+    errors: list[str] = []
+    hso = output.get("hookSpecificOutput", {})
+
+    if hso:
+        event_name = hso.get("hookEventName")
+        if event_name and event_name != "PostToolUse":
+            errors.append(f"hookEventName must be 'PostToolUse', got '{event_name}'")
+
+    decision = output.get("decision")
+    if decision is not None and decision not in POSTTOOLUSE_VALID_DECISIONS:
+        errors.append(f"Invalid PostToolUse decision '{decision}'. Only 'block' is valid.")
+
+    return errors
+
+
+def _validate_stop(output: dict) -> list[str]:
+    errors: list[str] = []
+    decision = output.get("decision")
+    if decision is not None and decision not in STOP_VALID_DECISIONS:
+        errors.append(
+            f"Invalid Stop decision '{decision}'. Only 'block' is valid; omit to allow."
+        )
+    # Stop hooks must NOT use hookSpecificOutput
+    if "hookSpecificOutput" in output:
+        errors.append("Stop hooks must not use hookSpecificOutput")
+    return errors
+
+
+def _validate_user_prompt_submit(output: dict) -> list[str]:
+    errors: list[str] = []
+    hso = output.get("hookSpecificOutput", {})
+
+    if hso:
+        event_name = hso.get("hookEventName")
+        if event_name and event_name != "UserPromptSubmit":
+            errors.append(
+                f"hookEventName must be 'UserPromptSubmit', got '{event_name}'"
+            )
+
+    decision = output.get("decision")
+    if decision is not None and decision not in USERPROMPTSUBMIT_VALID_DECISIONS:
+        errors.append(
+            f"Invalid UserPromptSubmit decision '{decision}'. Only 'block' is valid."
+        )
+
+    return errors

--- a/tests/test_adversarial_review.py
+++ b/tests/test_adversarial_review.py
@@ -149,6 +149,53 @@ class TestIsSahjhanCmdQuotedEnvVarBypass:
 
 
 # ═══════════════════════════════════════════════════════════════════════
+# Bug 5: Newline-separated commands bypass commit gate and protocol tracking
+#
+# Root cause: _split_shell_segments, _is_tdd_cmd, _is_test_cmd, and
+# _is_sleep_cmd split on &&, ||, ;, | but NOT on \n (newline).
+# However, _sahjhan_bootstrap.py DOES split on \n. This dual-parser
+# divergence means "echo\ngit commit" bypasses commit_gate while
+# "echo\nrm enforcement/foo.py" is correctly blocked by bootstrap.
+#
+# Impact: Newline-separated git commits bypass the commit gate entirely.
+# The commit happens but is invisible to enforcement tracking.
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestNewlineSeparatedCommandBypass:
+    """Commands separated by newlines must be detected, not treated as one segment."""
+
+    def test_newline_git_commit_detected(self):
+        """echo hello\\ngit commit -m 'fix: x' IS a git commit."""
+        from _protocol_cache import is_git_commit
+        assert is_git_commit("echo hello\ngit commit -m 'fix: x'"), (
+            "Newline-separated git commit was not detected — commit gate bypassed"
+        )
+
+    def test_newline_sahjhan_detected(self):
+        """echo hello\\nsahjhan status — contains a non-sahjhan segment."""
+        from _protocol_cache import is_sahjhan_cmd
+        # The whole command is NOT exclusively sahjhan (echo is non-sahjhan)
+        assert not is_sahjhan_cmd("echo hello\nsahjhan status"), (
+            "Mixed newline command should not be classified as pure sahjhan"
+        )
+
+    def test_newline_tdd_cmd_detected(self):
+        """echo hello\\npytest IS a TDD command."""
+        tracker = _load_with_enforcement_deps("protocol_tracker", "protocol_tracker.py")
+        assert tracker._is_tdd_cmd("echo hello\npytest"), (
+            "Newline-separated pytest was not detected as TDD"
+        )
+
+    def test_newline_sleep_detected(self):
+        """echo hello\\nsleep 60 IS a sleep command."""
+        tracker = _load_with_enforcement_deps("protocol_tracker", "protocol_tracker.py")
+        assert tracker._is_sleep_cmd("echo hello\nsleep 60"), (
+            "Newline-separated sleep was not detected"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
 # Bug 2: _is_tdd_cmd doesn't handle chained commands
 #
 # Root cause: _is_tdd_cmd checks cmd.strip().startswith("pytest") etc.

--- a/tests/test_bootstrap_read_guard.py
+++ b/tests/test_bootstrap_read_guard.py
@@ -35,7 +35,7 @@ class TestSahjhanAllowlist:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert "not permitted" in output["hookSpecificOutput"]["permissionDecisionReason"]
 
     def test_sahjhan_reset_with_proof_blocked(self):
@@ -46,7 +46,7 @@ class TestSahjhanAllowlist:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_sahjhan_unknown_subcommand_blocked(self):
         """Unknown subcommands are blocked by the allowlist."""
@@ -56,7 +56,7 @@ class TestSahjhanAllowlist:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_bare_sahjhan_blocked(self):
         """Bare 'sahjhan' with no subcommand is blocked."""
@@ -66,7 +66,7 @@ class TestSahjhanAllowlist:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_sahjhan_with_config_dir_flag_allowed(self):
         """Flags before the subcommand should be skipped; status is allowed."""
@@ -86,7 +86,7 @@ class TestSahjhanAllowlist:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_sahjhan_daemon_start_allowed(self):
         """daemon start is allowed."""
@@ -146,7 +146,7 @@ class TestSahjhanAllowlist:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_case_insensitive_reset_blocked(self):
         """Case-insensitive matching must catch mixed-case sahjhan commands."""
@@ -156,7 +156,7 @@ class TestSahjhanAllowlist:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_non_sahjhan_command_allowed(self):
         """Normal bash commands should be allowed."""
@@ -214,7 +214,7 @@ class TestWriteGuardsRetained:
             "cwd": repo_root,
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_sed_inplace_to_protected_blocked(self):
         event = {
@@ -223,7 +223,7 @@ class TestWriteGuardsRetained:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_bash_redirect_to_managed_status_blocked(self):
         event = {
@@ -232,7 +232,7 @@ class TestWriteGuardsRetained:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
 class TestExtractSahjhanSubcmd:
@@ -317,7 +317,7 @@ class TestEnvVarPrefixBypassesAllowlist:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block", (
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny", (
             "Env var prefix bypassed sahjhan subcommand allowlist — "
             "'FOO=bar sahjhan reset' was allowed through"
         )
@@ -330,7 +330,7 @@ class TestEnvVarPrefixBypassesAllowlist:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block", (
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny", (
             "Multiple env var prefixes bypassed sahjhan allowlist"
         )
 
@@ -351,7 +351,7 @@ class TestEnvVarPrefixBypassesWriteProtection:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block", (
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny", (
             "Env var prefix bypassed rm write protection on .sahjhan dir"
         )
 
@@ -363,7 +363,7 @@ class TestEnvVarPrefixBypassesWriteProtection:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block", (
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny", (
             "Env var prefix bypassed cp write protection on enforcement/"
         )
 
@@ -375,7 +375,7 @@ class TestEnvVarPrefixBypassesWriteProtection:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block", (
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny", (
             "Env var prefix bypassed sed write protection on enforcement/"
         )
 
@@ -387,7 +387,7 @@ class TestEnvVarPrefixBypassesWriteProtection:
             "cwd": "/tmp/fake-cwd",
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block", (
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny", (
             "Env var prefix bypassed redirect write protection on managed doc"
         )
 
@@ -405,7 +405,7 @@ class TestManagedDataWriteProtection:
             "cwd": repo_root,
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert "cannot be modified" in output["hookSpecificOutput"]["permissionDecisionReason"]
 
     def test_edit_to_active_ledger_marker_blocked(self):
@@ -422,7 +422,7 @@ class TestManagedDataWriteProtection:
             "cwd": repo_root,
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_write_to_daemon_pid_blocked(self):
         """Write tool targeting daemon.pid must be blocked."""
@@ -434,7 +434,7 @@ class TestManagedDataWriteProtection:
             "cwd": repo_root,
         }
         output = _run_hook(event)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_write_outside_sahjhan_dir_allowed(self):
         """Write tool targeting a non-protected path is allowed."""

--- a/tests/test_bootstrap_read_guard.py
+++ b/tests/test_bootstrap_read_guard.py
@@ -445,3 +445,101 @@ class TestManagedDataWriteProtection:
         }
         output = _run_hook(event)
         assert output["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+class TestCopyMoveTargetDirectoryBypass:
+    """cp/mv -t and --target-directory bypass: target is NOT the last arg."""
+
+    def test_cp_t_flag_to_enforcement_blocked(self):
+        """cp -t enforcement/hooks/ must be blocked."""
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "cp -t enforcement/hooks/ /tmp/evil.py"},
+            "cwd": "/tmp/fake-cwd",
+        }
+        output = _run_hook(event)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_mv_t_flag_to_enforcement_blocked(self):
+        """mv -t enforcement/hooks/ must be blocked."""
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "mv -t enforcement/hooks/ /tmp/evil.py"},
+            "cwd": "/tmp/fake-cwd",
+        }
+        output = _run_hook(event)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_cp_target_directory_long_flag_blocked(self):
+        """cp --target-directory=enforcement/ must be blocked."""
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "cp --target-directory=enforcement/ /tmp/evil.py"},
+            "cwd": "/tmp/fake-cwd",
+        }
+        output = _run_hook(event)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_mv_target_directory_space_flag_blocked(self):
+        """mv --target-directory enforcement/ must be blocked."""
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "mv --target-directory enforcement/ /tmp/evil.py"},
+            "cwd": "/tmp/fake-cwd",
+        }
+        output = _run_hook(event)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+class TestFullPathCommandBypass:
+    """Full-path commands (/bin/cp, /usr/bin/rm) must be caught."""
+
+    def test_bin_cp_to_enforcement_blocked(self):
+        """/bin/cp to enforcement/ must be blocked."""
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "/bin/cp /tmp/evil.py enforcement/hooks/foo.py"},
+            "cwd": "/tmp/fake-cwd",
+        }
+        output = _run_hook(event)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_usr_bin_mv_to_enforcement_blocked(self):
+        """/usr/bin/mv to enforcement/ must be blocked."""
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "/usr/bin/mv /tmp/evil.py enforcement/hooks/foo.py"},
+            "cwd": "/tmp/fake-cwd",
+        }
+        output = _run_hook(event)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_bin_rm_sahjhan_dir_blocked(self):
+        """/bin/rm -rf docs/holtz/.sahjhan/ must be blocked."""
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "/bin/rm -rf docs/holtz/.sahjhan/"},
+            "cwd": "/tmp/fake-cwd",
+        }
+        output = _run_hook(event)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_usr_bin_rmdir_sahjhan_blocked(self):
+        """/usr/bin/rmdir docs/holtz/.sahjhan/ must be blocked."""
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "/usr/bin/rmdir docs/holtz/.sahjhan/"},
+            "cwd": "/tmp/fake-cwd",
+        }
+        output = _run_hook(event)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_full_path_cp_safe_target_allowed(self):
+        """/bin/cp to a non-protected path must be allowed."""
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "/bin/cp file.txt /tmp/safe.txt"},
+            "cwd": "/tmp/fake-cwd",
+        }
+        output = _run_hook(event)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "allow"

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -178,22 +178,24 @@ class TestExitStopWarn:
             output = {}
         return result.returncode, output
 
-    def test_outputs_approve_decision(self):
-        """exit_stop_warn outputs decision=approve so stop proceeds."""
+    def test_outputs_system_message(self):
+        """exit_stop_warn outputs systemMessage (allows stop, shows msg to user)."""
         code, output = self._run_func("exit_stop_warn", "test warning")
         assert code == 0
-        assert output.get("decision") == "approve"
+        assert output.get("systemMessage") == "test warning"
+        assert "decision" not in output
 
-    def test_includes_reason(self):
-        """exit_stop_warn includes the warning message as reason."""
+    def test_includes_warning_text(self):
+        """exit_stop_warn includes the warning message in systemMessage."""
         _, output = self._run_func("exit_stop_warn", "enforcement unavailable")
-        assert output.get("reason") == "enforcement unavailable"
+        assert output.get("systemMessage") == "enforcement unavailable"
 
     def test_no_pretooluse_fields(self):
         """Stop hooks should not include PreToolUse-specific fields."""
         _, output = self._run_func("exit_stop_warn", "test")
         assert "hookSpecificOutput" not in output
         assert "continue" not in output
+        assert "decision" not in output
 
     def test_produces_output_unlike_allow(self):
         """exit_stop_warn produces output (hasOutput=true) unlike exit_stop_allow."""
@@ -253,9 +255,11 @@ class TestStopHookDegradedEnforcement:
         assert code == 0
         # Should have output (not silent allow)
         assert output != {}, "Stop hook silently allowed despite active audit with no config"
-        # Should be a warning, not a block
-        reason = output.get("reason", "")
-        assert "WARNING" in reason or "enforcement" in reason.lower()
+        # Should be a warning (systemMessage), not a block
+        msg = output.get("systemMessage", "")
+        assert "unavailable" in msg.lower() or "enforcement" in msg.lower() or "status-cache" in msg.lower(), (
+            f"Warn message should mention enforcement/unavailable/status-cache, got: {msg}"
+        )
 
     def test_warns_include_config_path(self, tmp_path):
         """Warning message should include the config path that was searched."""
@@ -266,8 +270,8 @@ class TestStopHookDegradedEnforcement:
 
         event = {"cwd": str(tmp_path)}
         code, output = self._run_stop_hook(event, cwd=str(tmp_path))
-        reason = output.get("reason", "")
-        assert "protocol.toml" in reason or "enforcement" in reason.lower()
+        msg = output.get("systemMessage", "")
+        assert "protocol.toml" in msg or "enforcement" in msg.lower() or "status-cache" in msg.lower()
 
     def test_uses_plugin_root_config(self, tmp_path):
         """Stop hook uses CLAUDE_PLUGIN_ROOT/enforcement when available."""

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -21,7 +21,7 @@ class TestDaemonLifecycleNoAudit:
         event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
         assert code == 0
-        assert output.get("continue") is True
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
 
     def test_allows_when_no_runs_and_no_marker(self, tmp_path):
         """Data dir exists but no runs/ and no active-run marker → allow, no action."""
@@ -29,7 +29,7 @@ class TestDaemonLifecycleNoAudit:
         event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
         assert code == 0
-        assert output.get("continue") is True
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
 
 
 class TestDaemonDeathTerminatesAudit:
@@ -45,7 +45,6 @@ class TestDaemonDeathTerminatesAudit:
         event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
         assert code == 0
-        assert output.get("continue") is False
         reason = output.get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
         assert "AUDIT TERMINATED" in reason
         assert (sahjhan_dir / "terminated").exists()
@@ -60,7 +59,7 @@ class TestDaemonDeathTerminatesAudit:
         event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
         assert code == 0
-        assert output.get("continue") is True
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
         assert not (sahjhan_dir / "terminated").exists()
 
     def test_blocks_fast_when_terminated_marker_exists(self, tmp_path):
@@ -72,7 +71,6 @@ class TestDaemonDeathTerminatesAudit:
         event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
         assert code == 0
-        assert output.get("continue") is False
         reason = output.get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
         assert "AUDIT TERMINATED" in reason
 
@@ -85,7 +83,7 @@ class TestDaemonDeathTerminatesAudit:
         event = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("_daemon_lifecycle.py", event, cwd=str(tmp_path))
         assert code == 0
-        assert output.get("continue") is True
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
 
     def test_writes_marker_not_cache(self, tmp_path):
         """Terminated marker written but no enforcement-cache.json (daemon-backed state)."""

--- a/tests/test_e2e_hook_invocation.py
+++ b/tests/test_e2e_hook_invocation.py
@@ -188,13 +188,19 @@ def posttooluse_write_event(cwd: str) -> dict:
 
 
 def subagent_stop_event(cwd: str) -> dict:
-    """Realistic SubagentStop event."""
+    """Realistic SubagentStop event.
+
+    Claude Code sends last_assistant_message with the subagent's final output.
+    This is the primary input for SubagentStop hooks like subagent_findings_check.py
+    and lens_quiz.py.
+    """
     return {
         "tool_name": "Agent",
         "tool_input": {
             "prompt": "Find all bugs in src/",
         },
         "tool_output": "Found 3 issues:\n1. Missing null check\n2. Race condition\n3. Memory leak",
+        "last_assistant_message": "I analyzed src/ and found 3 issues:\n1. Missing null check in src/auth.py\n2. Race condition in src/cache.py\n3. Memory leak in src/worker.py",
         "cwd": cwd,
     }
 
@@ -285,7 +291,8 @@ def validate_posttooluse_output(output: dict, hook_cmd: str) -> list[str]:
 
     Valid responses:
     - Allow: {"continue": true, "suppressOutput": true}
-    - Warn: {"continue": true, "suppressOutput": false, "additionalContext": str}
+    - Warn (user): {"continue": true, "suppressOutput": false, "systemMessage": str}
+    - Warn (Claude): {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": str}}
     - Empty dict (legacy allow)
     """
     errors = []
@@ -297,11 +304,27 @@ def validate_posttooluse_output(output: dict, hook_cmd: str) -> list[str]:
     if not output:
         return errors  # Empty = allow
 
+    # hookSpecificOutput format — injects context into Claude's next prompt
+    hook_specific = output.get("hookSpecificOutput", {})
+    if hook_specific:
+        event_name = hook_specific.get("hookEventName")
+        if event_name != "PostToolUse":
+            errors.append(
+                f"hookEventName must be 'PostToolUse', got '{event_name}' from {hook_cmd}"
+            )
+        # PostToolUse hookSpecificOutput should NOT have permissionDecision
+        if "permissionDecision" in hook_specific:
+            errors.append(
+                f"PostToolUse hookSpecificOutput should not have permissionDecision from {hook_cmd}"
+            )
+        return errors
+
+    # Generic format — continue/suppressOutput/systemMessage
     if "continue" not in output:
         errors.append(f"Missing 'continue' key in PostToolUse output from {hook_cmd}: {output}")
         return errors
 
-    # PostToolUse hooks should NOT block with hookSpecificOutput/permissionDecision
+    # PostToolUse hooks should NOT block
     if output.get("continue") is False:
         errors.append(
             f"PostToolUse hook {hook_cmd} returned continue=false — "
@@ -354,7 +377,8 @@ def validate_user_prompt_submit_output(output: dict, hook_cmd: str) -> list[str]
 
     Valid responses:
     - Allow: {"continue": true, "suppressOutput": true}
-    - Modify: {"continue": true, "suppressOutput": false, "additionalContext": str}
+    - Inject (user): {"continue": true, "suppressOutput": false, "systemMessage": str}
+    - Inject (Claude): {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": str}}
     """
     errors = []
 
@@ -365,6 +389,17 @@ def validate_user_prompt_submit_output(output: dict, hook_cmd: str) -> list[str]
     if not output:
         return errors  # Empty = allow
 
+    # hookSpecificOutput format — injects context into Claude's next prompt
+    hook_specific = output.get("hookSpecificOutput", {})
+    if hook_specific:
+        event_name = hook_specific.get("hookEventName")
+        if event_name != "UserPromptSubmit":
+            errors.append(
+                f"hookEventName must be 'UserPromptSubmit', got '{event_name}' from {hook_cmd}"
+            )
+        return errors
+
+    # Generic format
     if "continue" not in output:
         errors.append(f"Missing 'continue' in UserPromptSubmit output from {hook_cmd}: {output}")
 

--- a/tests/test_e2e_hook_invocation.py
+++ b/tests/test_e2e_hook_invocation.py
@@ -217,13 +217,20 @@ def user_prompt_submit_event(cwd: str) -> dict:
 # ─── Schema validators ──────────────────────────────────────────────────
 
 
-def validate_pretooluse_output(output: dict, hook_cmd: str) -> list[str]:
-    """Validate PreToolUse hook output matches Claude Code's expected schema.
+_VALID_PERMISSION_DECISIONS = {"allow", "deny", "ask", "defer"}
 
-    Valid responses:
-    - Allow: {"continue": true, "suppressOutput": true, ...}
-    - Warn: {"continue": true, "suppressOutput": false, "additionalContext": str}
-    - Block: {"continue": false, "hookSpecificOutput": {"permissionDecision": "block", ...}}
+
+def validate_pretooluse_output(output: dict, hook_cmd: str) -> list[str]:
+    """Validate PreToolUse hook output matches Claude Code's ACTUAL schema.
+
+    PreToolUse hooks use hookSpecificOutput.permissionDecision as the
+    primary control mechanism. Valid permissionDecision values are:
+    "allow", "deny", "ask", "defer".
+
+    "continue" is a universal field that stops Claude entirely when false —
+    it is NOT how you deny a tool call. Tool denial uses permissionDecision.
+
+    See: https://code.claude.com/docs/en/hooks
     """
     errors = []
 
@@ -232,25 +239,43 @@ def validate_pretooluse_output(output: dict, hook_cmd: str) -> list[str]:
         return errors
 
     if not output:
-        # Empty output is valid for some hooks (legacy allow)
+        # Empty output is valid (default allow)
         return errors
 
-    if "continue" not in output:
-        errors.append(f"Missing 'continue' key in output from {hook_cmd}: {output}")
-        return errors
+    hook_specific = output.get("hookSpecificOutput", {})
 
-    if output["continue"] is True:
-        if "suppressOutput" not in output:
-            errors.append(f"Missing 'suppressOutput' in allow/warn response from {hook_cmd}")
-    elif output["continue"] is False:
-        hook_specific = output.get("hookSpecificOutput", {})
-        if not hook_specific:
-            errors.append(f"Block response missing 'hookSpecificOutput' from {hook_cmd}")
-        elif hook_specific.get("permissionDecision") not in ("block", "allow"):
+    if hook_specific:
+        # Validate hookSpecificOutput fields against Claude Code's real schema
+        if hook_specific.get("hookEventName") != "PreToolUse":
             errors.append(
-                f"Invalid permissionDecision '{hook_specific.get('permissionDecision')}' "
+                f"hookEventName must be 'PreToolUse', got '{hook_specific.get('hookEventName')}' "
                 f"from {hook_cmd}"
             )
+        decision = hook_specific.get("permissionDecision")
+        if decision not in _VALID_PERMISSION_DECISIONS:
+            errors.append(
+                f"Invalid permissionDecision '{decision}' from {hook_cmd}. "
+                f"Valid values: {_VALID_PERMISSION_DECISIONS}"
+            )
+    else:
+        # No hookSpecificOutput — only universal fields are allowed.
+        # "continue" is optional (defaults to true). Check for invalid
+        # top-level fields that belong inside hookSpecificOutput.
+        bad_fields = {"permissionDecision", "additionalContext"} & set(output.keys())
+        if bad_fields:
+            errors.append(
+                f"Fields {bad_fields} must be inside hookSpecificOutput, not at "
+                f"top level, from {hook_cmd}"
+            )
+
+    # "continue: false" is NOT how you deny a tool — it stops Claude entirely.
+    # Flag it as likely wrong if combined with permissionDecision deny.
+    if output.get("continue") is False and hook_specific.get("permissionDecision") == "deny":
+        errors.append(
+            f"Hook {hook_cmd} uses both continue=false AND permissionDecision='deny'. "
+            "continue=false stops Claude entirely — use permissionDecision='deny' alone "
+            "to deny a tool call."
+        )
 
     return errors
 
@@ -287,12 +312,15 @@ def validate_posttooluse_output(output: dict, hook_cmd: str) -> list[str]:
 
 
 def validate_stop_output(output: dict, hook_cmd: str) -> list[str]:
-    """Validate Stop hook output.
+    """Validate Stop/SubagentStop hook output against Claude Code's schema.
 
     Valid responses:
-    - Allow: empty dict (no output)
-    - Warn/Allow: {"decision": "approve", "reason": str}
+    - Allow: empty dict (no output, exit 0)
+    - Warn/Allow: {"systemMessage": str}  (allows stop, shows msg to user)
     - Block: {"decision": "block", "reason": str}
+
+    The only valid decision value is "block". Omit decision to allow.
+    See: https://code.claude.com/docs/en/hooks
     """
     errors = []
 
@@ -303,14 +331,11 @@ def validate_stop_output(output: dict, hook_cmd: str) -> list[str]:
     if not output:
         return errors  # Empty = allow
 
-    if "decision" not in output:
-        errors.append(f"Stop hook output missing 'decision' key from {hook_cmd}: {output}")
-        return errors
-
-    if output["decision"] not in ("block", "approve"):
+    decision = output.get("decision")
+    if decision is not None and decision != "block":
         errors.append(
-            f"Invalid Stop decision '{output['decision']}' from {hook_cmd} "
-            "(expected 'block' or 'approve')"
+            f"Invalid Stop decision '{decision}' from {hook_cmd}. "
+            "Only 'block' is valid; omit 'decision' to allow."
         )
 
     return errors

--- a/tests/test_e2e_hook_invocation.py
+++ b/tests/test_e2e_hook_invocation.py
@@ -222,188 +222,42 @@ def user_prompt_submit_event(cwd: str) -> dict:
 
 # ─── Schema validators ──────────────────────────────────────────────────
 
-
-_VALID_PERMISSION_DECISIONS = {"allow", "deny", "ask", "defer"}
+from hook_schema import validate_hook_output
 
 
 def validate_pretooluse_output(output: dict, hook_cmd: str) -> list[str]:
-    """Validate PreToolUse hook output matches Claude Code's ACTUAL schema.
-
-    PreToolUse hooks use hookSpecificOutput.permissionDecision as the
-    primary control mechanism. Valid permissionDecision values are:
-    "allow", "deny", "ask", "defer".
-
-    "continue" is a universal field that stops Claude entirely when false —
-    it is NOT how you deny a tool call. Tool denial uses permissionDecision.
-
-    See: https://code.claude.com/docs/en/hooks
-    """
-    errors = []
-
+    """Validate PreToolUse output against the canonical schema."""
     if "__raw_stdout" in output:
-        errors.append(f"Invalid JSON output from {hook_cmd}: {output['__raw_stdout'][:200]}")
-        return errors
-
-    if not output:
-        # Empty output is valid (default allow)
-        return errors
-
-    hook_specific = output.get("hookSpecificOutput", {})
-
-    if hook_specific:
-        # Validate hookSpecificOutput fields against Claude Code's real schema
-        if hook_specific.get("hookEventName") != "PreToolUse":
-            errors.append(
-                f"hookEventName must be 'PreToolUse', got '{hook_specific.get('hookEventName')}' "
-                f"from {hook_cmd}"
-            )
-        decision = hook_specific.get("permissionDecision")
-        if decision not in _VALID_PERMISSION_DECISIONS:
-            errors.append(
-                f"Invalid permissionDecision '{decision}' from {hook_cmd}. "
-                f"Valid values: {_VALID_PERMISSION_DECISIONS}"
-            )
-    else:
-        # No hookSpecificOutput — only universal fields are allowed.
-        # "continue" is optional (defaults to true). Check for invalid
-        # top-level fields that belong inside hookSpecificOutput.
-        bad_fields = {"permissionDecision", "additionalContext"} & set(output.keys())
-        if bad_fields:
-            errors.append(
-                f"Fields {bad_fields} must be inside hookSpecificOutput, not at "
-                f"top level, from {hook_cmd}"
-            )
-
-    # "continue: false" is NOT how you deny a tool — it stops Claude entirely.
-    # Flag it as likely wrong if combined with permissionDecision deny.
-    if output.get("continue") is False and hook_specific.get("permissionDecision") == "deny":
-        errors.append(
-            f"Hook {hook_cmd} uses both continue=false AND permissionDecision='deny'. "
-            "continue=false stops Claude entirely — use permissionDecision='deny' alone "
-            "to deny a tool call."
-        )
-
-    return errors
+        return [f"Invalid JSON from {hook_cmd}: {output['__raw_stdout'][:200]}"]
+    return [f"{hook_cmd}: {e}" for e in validate_hook_output("PreToolUse", output)]
 
 
 def validate_posttooluse_output(output: dict, hook_cmd: str) -> list[str]:
-    """Validate PostToolUse hook output.
-
-    Valid responses:
-    - Allow: {"continue": true, "suppressOutput": true}
-    - Warn (user): {"continue": true, "suppressOutput": false, "systemMessage": str}
-    - Warn (Claude): {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": str}}
-    - Empty dict (legacy allow)
-    """
-    errors = []
-
+    """Validate PostToolUse output against the canonical schema."""
     if "__raw_stdout" in output:
-        errors.append(f"Invalid JSON output from {hook_cmd}: {output['__raw_stdout'][:200]}")
-        return errors
-
-    if not output:
-        return errors  # Empty = allow
-
-    # hookSpecificOutput format — injects context into Claude's next prompt
-    hook_specific = output.get("hookSpecificOutput", {})
-    if hook_specific:
-        event_name = hook_specific.get("hookEventName")
-        if event_name != "PostToolUse":
-            errors.append(
-                f"hookEventName must be 'PostToolUse', got '{event_name}' from {hook_cmd}"
-            )
-        # PostToolUse hookSpecificOutput should NOT have permissionDecision
-        if "permissionDecision" in hook_specific:
-            errors.append(
-                f"PostToolUse hookSpecificOutput should not have permissionDecision from {hook_cmd}"
-            )
-        return errors
-
-    # Generic format — continue/suppressOutput/systemMessage
-    if "continue" not in output:
-        errors.append(f"Missing 'continue' key in PostToolUse output from {hook_cmd}: {output}")
-        return errors
-
-    # PostToolUse hooks should NOT block
-    if output.get("continue") is False:
-        errors.append(
-            f"PostToolUse hook {hook_cmd} returned continue=false — "
-            "PostToolUse hooks cannot block (tool already executed)"
-        )
-
-    return errors
+        return [f"Invalid JSON from {hook_cmd}: {output['__raw_stdout'][:200]}"]
+    return [f"{hook_cmd}: {e}" for e in validate_hook_output("PostToolUse", output)]
 
 
 def validate_stop_output(output: dict, hook_cmd: str) -> list[str]:
-    """Validate Stop/SubagentStop hook output against Claude Code's schema.
-
-    Valid responses:
-    - Allow: empty dict (no output, exit 0)
-    - Warn/Allow: {"systemMessage": str}  (allows stop, shows msg to user)
-    - Block: {"decision": "block", "reason": str}
-
-    The only valid decision value is "block". Omit decision to allow.
-    See: https://code.claude.com/docs/en/hooks
-    """
-    errors = []
-
+    """Validate Stop output against the canonical schema."""
     if "__raw_stdout" in output:
-        errors.append(f"Invalid JSON output from {hook_cmd}: {output['__raw_stdout'][:200]}")
-        return errors
-
-    if not output:
-        return errors  # Empty = allow
-
-    decision = output.get("decision")
-    if decision is not None and decision != "block":
-        errors.append(
-            f"Invalid Stop decision '{decision}' from {hook_cmd}. "
-            "Only 'block' is valid; omit 'decision' to allow."
-        )
-
-    return errors
+        return [f"Invalid JSON from {hook_cmd}: {output['__raw_stdout'][:200]}"]
+    return [f"{hook_cmd}: {e}" for e in validate_hook_output("Stop", output)]
 
 
 def validate_subagent_stop_output(output: dict, hook_cmd: str) -> list[str]:
-    """Validate SubagentStop hook output.
-
-    Same schema as Stop hooks.
-    """
-    return validate_stop_output(output, hook_cmd)
+    """Validate SubagentStop output against the canonical schema."""
+    if "__raw_stdout" in output:
+        return [f"Invalid JSON from {hook_cmd}: {output['__raw_stdout'][:200]}"]
+    return [f"{hook_cmd}: {e}" for e in validate_hook_output("SubagentStop", output)]
 
 
 def validate_user_prompt_submit_output(output: dict, hook_cmd: str) -> list[str]:
-    """Validate UserPromptSubmit hook output.
-
-    Valid responses:
-    - Allow: {"continue": true, "suppressOutput": true}
-    - Inject (user): {"continue": true, "suppressOutput": false, "systemMessage": str}
-    - Inject (Claude): {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": str}}
-    """
-    errors = []
-
+    """Validate UserPromptSubmit output against the canonical schema."""
     if "__raw_stdout" in output:
-        errors.append(f"Invalid JSON output from {hook_cmd}: {output['__raw_stdout'][:200]}")
-        return errors
-
-    if not output:
-        return errors  # Empty = allow
-
-    # hookSpecificOutput format — injects context into Claude's next prompt
-    hook_specific = output.get("hookSpecificOutput", {})
-    if hook_specific:
-        event_name = hook_specific.get("hookEventName")
-        if event_name != "UserPromptSubmit":
-            errors.append(
-                f"hookEventName must be 'UserPromptSubmit', got '{event_name}' from {hook_cmd}"
-            )
-        return errors
-
-    # Generic format
-    if "continue" not in output:
-        errors.append(f"Missing 'continue' in UserPromptSubmit output from {hook_cmd}: {output}")
-
-    return errors
+        return [f"Invalid JSON from {hook_cmd}: {output['__raw_stdout'][:200]}"]
+    return [f"{hook_cmd}: {e}" for e in validate_hook_output("UserPromptSubmit", output)]
 
 
 # ─── Fixtures ────────────────────────────────────────────────────────────

--- a/tests/test_enforcement_config.py
+++ b/tests/test_enforcement_config.py
@@ -1,6 +1,7 @@
 """Tests for enforcement TOML configuration files."""
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -305,6 +306,19 @@ def test_settings_local_has_no_enforcement_hooks():
         f"Enforcement hooks must not be in settings.local.json (found: {enforcement_hooks}). "
         "They belong in hooks/hooks.json (plugin mode only)."
     )
+
+
+def test_pre_release_hook_validation_gate():
+    """Pre-release gate: smoke test script exists and is executable."""
+    smoke_test = Path(__file__).parent.parent / "scripts" / "smoke-test-hooks.sh"
+    assert smoke_test.exists(), "scripts/smoke-test-hooks.sh missing"
+    assert os.access(smoke_test, os.X_OK), "scripts/smoke-test-hooks.sh not executable"
+
+
+def test_hook_schema_exists():
+    """Pre-release gate: hook_schema.py must exist as source of truth."""
+    schema = Path(__file__).parent / "hook_schema.py"
+    assert schema.exists(), "tests/hook_schema.py missing — hooks have no schema to validate against"
 
 
 def test_hooks_json_registers_enforcement_hooks():

--- a/tests/test_enforcement_config.py
+++ b/tests/test_enforcement_config.py
@@ -280,32 +280,30 @@ def test_mypy_uses_explicit_package_bases():
 # ── Tasks 5 & 6: Hook registration ──
 
 
-def test_settings_local_registers_enforcement_hooks():
-    """Dev-mode settings must register commit_gate and protocol_tracker."""
+def test_settings_local_has_no_enforcement_hooks():
+    """settings.local.json must NOT register enforcement hooks.
+
+    Enforcement hooks run via the plugin (hooks/hooks.json), not via
+    project settings. Having them in settings.local.json causes them
+    to fire during plugin development, blocking edits to the hooks
+    themselves. See: two broken releases from this exact mistake.
+    """
     settings_path = Path(__file__).parent.parent / ".claude" / "settings.local.json"
     if not settings_path.exists():
         pytest.skip(".claude/settings.local.json not present (not tracked in git)")
     cfg = json.loads(settings_path.read_text())
     hooks = cfg.get("hooks", {})
 
-    pre_tool = hooks.get("PreToolUse", [])
-    post_tool = hooks.get("PostToolUse", [])
+    all_commands = []
+    for event_hooks in hooks.values():
+        for entry in event_hooks if isinstance(event_hooks, list) else []:
+            for h in entry.get("hooks", []):
+                all_commands.append(h.get("command", ""))
 
-    pre_commands = []
-    for entry in pre_tool:
-        for h in entry.get("hooks", []):
-            pre_commands.append(h.get("command", ""))
-
-    post_commands = []
-    for entry in post_tool:
-        for h in entry.get("hooks", []):
-            post_commands.append(h.get("command", ""))
-
-    assert any("commit_gate" in c for c in pre_commands), (
-        "commit_gate.py not registered in settings.local.json PreToolUse"
-    )
-    assert any("protocol_tracker" in c for c in post_commands), (
-        "protocol_tracker.py not registered in settings.local.json PostToolUse"
+    enforcement_hooks = [c for c in all_commands if "enforcement/" in c]
+    assert not enforcement_hooks, (
+        f"Enforcement hooks must not be in settings.local.json (found: {enforcement_hooks}). "
+        "They belong in hooks/hooks.json (plugin mode only)."
     )
 
 

--- a/tests/test_hook_schema.py
+++ b/tests/test_hook_schema.py
@@ -1,10 +1,7 @@
 """Tests that hook_schema.py is internally consistent and complete."""
-import pytest
-
 from hook_schema import (
     PRETOOLUSE_VALID_DECISIONS,
     STOP_VALID_DECISIONS,
-    UNIVERSAL_FIELDS,
     validate_hook_output,
 )
 
@@ -25,7 +22,7 @@ def test_pretooluse_does_not_have_block():
 
 def test_stop_only_has_block():
     """Stop hooks only support 'block' for decision."""
-    assert STOP_VALID_DECISIONS == {"block"}
+    assert {"block"} == STOP_VALID_DECISIONS
 
 
 def test_validate_pretooluse_allow():
@@ -104,6 +101,7 @@ def test_validate_posttooluse_with_hook_specific():
 def test_e2e_validators_delegate_to_schema():
     """E2E validators must use hook_schema, not independent logic."""
     import inspect
+
     import test_e2e_hook_invocation as e2e
     # The validators must import from hook_schema
     src = inspect.getsource(e2e.validate_pretooluse_output)

--- a/tests/test_hook_schema.py
+++ b/tests/test_hook_schema.py
@@ -99,3 +99,14 @@ def test_validate_posttooluse_with_hook_specific():
         },
     })
     assert errs == []
+
+
+def test_e2e_validators_delegate_to_schema():
+    """E2E validators must use hook_schema, not independent logic."""
+    import inspect
+    import test_e2e_hook_invocation as e2e
+    # The validators must import from hook_schema
+    src = inspect.getsource(e2e.validate_pretooluse_output)
+    assert "hook_schema" in src or "validate_hook_output" in src, (
+        "validate_pretooluse_output must delegate to hook_schema"
+    )

--- a/tests/test_hook_schema.py
+++ b/tests/test_hook_schema.py
@@ -1,0 +1,101 @@
+"""Tests that hook_schema.py is internally consistent and complete."""
+import pytest
+
+from hook_schema import (
+    PRETOOLUSE_VALID_DECISIONS,
+    STOP_VALID_DECISIONS,
+    UNIVERSAL_FIELDS,
+    validate_hook_output,
+)
+
+
+def test_pretooluse_decisions_are_strings():
+    assert all(isinstance(d, str) for d in PRETOOLUSE_VALID_DECISIONS)
+
+
+def test_pretooluse_has_deny():
+    """The value that blocks a tool call must exist."""
+    assert "deny" in PRETOOLUSE_VALID_DECISIONS
+
+
+def test_pretooluse_does_not_have_block():
+    """'block' is the OLD deprecated value — must not be listed."""
+    assert "block" not in PRETOOLUSE_VALID_DECISIONS
+
+
+def test_stop_only_has_block():
+    """Stop hooks only support 'block' for decision."""
+    assert STOP_VALID_DECISIONS == {"block"}
+
+
+def test_validate_pretooluse_allow():
+    errs = validate_hook_output("PreToolUse", {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+        },
+    })
+    assert errs == []
+
+
+def test_validate_pretooluse_deny():
+    errs = validate_hook_output("PreToolUse", {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": "blocked",
+        },
+    })
+    assert errs == []
+
+
+def test_validate_pretooluse_rejects_block():
+    errs = validate_hook_output("PreToolUse", {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "block",
+        },
+    })
+    assert len(errs) == 1
+    assert "block" in errs[0]
+
+
+def test_validate_pretooluse_rejects_continue_false_with_deny():
+    errs = validate_hook_output("PreToolUse", {
+        "continue": False,
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+        },
+    })
+    assert any("continue" in e for e in errs)
+
+
+def test_validate_stop_allow_empty():
+    errs = validate_hook_output("Stop", {})
+    assert errs == []
+
+
+def test_validate_stop_block():
+    errs = validate_hook_output("Stop", {"decision": "block", "reason": "not done"})
+    assert errs == []
+
+
+def test_validate_stop_rejects_approve():
+    errs = validate_hook_output("Stop", {"decision": "approve", "reason": "done"})
+    assert len(errs) == 1
+
+
+def test_validate_posttooluse_allow():
+    errs = validate_hook_output("PostToolUse", {"continue": True, "suppressOutput": True})
+    assert errs == []
+
+
+def test_validate_posttooluse_with_hook_specific():
+    errs = validate_hook_output("PostToolUse", {
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": "warning",
+        },
+    })
+    assert errs == []

--- a/tests/test_hook_schema_freshness.py
+++ b/tests/test_hook_schema_freshness.py
@@ -70,7 +70,7 @@ class TestPreToolUseDecisions:
 class TestStopDecisions:
 
     def test_block_is_only_stop_decision(self):
-        assert STOP_VALID_DECISIONS == {"block"}
+        assert {"block"} == STOP_VALID_DECISIONS
 
     def test_approve_not_valid_for_stop(self):
         """'approve' was never a valid Stop decision."""

--- a/tests/test_hook_schema_freshness.py
+++ b/tests/test_hook_schema_freshness.py
@@ -1,0 +1,77 @@
+"""Schema freshness gate — verifies hook_schema.py matches current Claude Code docs.
+
+This test fetches the official docs page and extracts valid field values.
+If Claude Code changes their spec, this test fails BEFORE we ship.
+
+Requires network access. Skipped in offline/CI environments.
+"""
+from __future__ import annotations
+
+import urllib.request
+
+import pytest
+
+from hook_schema import (
+    PRETOOLUSE_VALID_DECISIONS,
+    SPEC_URL,
+    STOP_VALID_DECISIONS,
+)
+
+
+def _fetch_docs() -> str:
+    """Fetch the Claude Code hooks docs page. Raises on failure."""
+    req = urllib.request.Request(SPEC_URL, headers={"User-Agent": "holtz-schema-check/1.0"})
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return resp.read().decode("utf-8")
+
+
+def _quoted_in(value: str, html: str) -> bool:
+    """Check if a value appears quoted in HTML (handles &quot; entities)."""
+    return f'"{value}"' in html or f"&quot;{value}&quot;" in html
+
+
+@pytest.fixture(scope="module")
+def docs_html() -> str:
+    try:
+        return _fetch_docs()
+    except Exception as e:
+        pytest.skip(f"Cannot fetch docs (offline?): {e}")
+
+
+@pytest.mark.network
+class TestPreToolUseDecisions:
+    """Verify permissionDecision enum matches the live docs."""
+
+    def test_allow_in_docs(self, docs_html: str):
+        assert _quoted_in("allow", docs_html)
+
+    def test_deny_in_docs(self, docs_html: str):
+        assert _quoted_in("deny", docs_html)
+
+    def test_ask_in_docs(self, docs_html: str):
+        assert _quoted_in("ask", docs_html)
+
+    def test_defer_in_docs(self, docs_html: str):
+        assert _quoted_in("defer", docs_html)
+
+    def test_block_not_in_pretooluse_decisions(self):
+        """'block' was deprecated for PreToolUse — must not be in our schema."""
+        assert "block" not in PRETOOLUSE_VALID_DECISIONS
+
+    def test_no_extra_decisions(self, docs_html: str):
+        """Every value in our schema must appear in the docs."""
+        for decision in PRETOOLUSE_VALID_DECISIONS:
+            assert _quoted_in(decision, docs_html), (
+                f"'{decision}' is in our schema but not found in docs — stale?"
+            )
+
+
+@pytest.mark.network
+class TestStopDecisions:
+
+    def test_block_is_only_stop_decision(self):
+        assert STOP_VALID_DECISIONS == {"block"}
+
+    def test_approve_not_valid_for_stop(self):
+        """'approve' was never a valid Stop decision."""
+        assert "approve" not in STOP_VALID_DECISIONS

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -68,11 +68,22 @@ def assert_blocked(code, output, reason_substring=""):
 
 
 def assert_warned(code, output, reason_substring=""):
-    """Assert that the hook warned but allowed the operation."""
+    """Assert that the hook warned but allowed the operation.
+
+    Accepts two valid warn formats:
+    1. Generic: {"continue": true, "suppressOutput": false, "systemMessage": msg}
+    2. hookSpecificOutput: {"hookSpecificOutput": {"additionalContext": msg}}
+    """
     assert code == 0, f"Expected exit 0, got {code}"
-    assert output.get("continue") is True
-    assert output.get("suppressOutput") is False
-    context = output.get("additionalContext", "")
+    hook_output = output.get("hookSpecificOutput", {})
+    if hook_output:
+        # hookSpecificOutput format — additionalContext is inside hookSpecificOutput
+        context = hook_output.get("additionalContext", "")
+    else:
+        # Generic format — systemMessage shown to user
+        assert output.get("continue") is True
+        assert output.get("suppressOutput") is False
+        context = output.get("systemMessage", "")
     if reason_substring:
         assert reason_substring in context
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,13 +1,14 @@
 """Tests for hooks/ modules.
 
 All hooks output modern-format JSON to stdout and exit 0.
-Decision semantics are encoded in the JSON payload:
+PreToolUse decisions use hookSpecificOutput.permissionDecision:
 
-  - allow:  {"continue": true,  "suppressOutput": true, ...}
-  - warn:   {"continue": true,  "suppressOutput": false, "additionalContext": ...}
-  - block:  {"continue": false, "hookSpecificOutput": {"permissionDecision": "block", ...}}
+  - allow:  hookSpecificOutput.permissionDecision = "allow"
+  - warn:   hookSpecificOutput.permissionDecision = "allow" + additionalContext
+  - deny:   hookSpecificOutput.permissionDecision = "deny"
 
-See: https://github.com/anthropics/claude-code/issues/17088
+Valid permissionDecision values: "allow", "deny", "ask", "defer".
+See: https://code.claude.com/docs/en/hooks
 """
 
 import json
@@ -41,18 +42,27 @@ def run_hook(hook_name, event, cwd=None):
 
 
 def assert_allowed(code, output):
-    """Assert that the hook allowed the operation."""
+    """Assert that the hook allowed the operation (PreToolUse).
+
+    Valid allow format: hookSpecificOutput.permissionDecision = "allow"
+    """
     assert code == 0, f"Expected exit 0, got {code}"
-    assert output.get("continue") is True
-    assert output.get("suppressOutput") is True
+    hook_output = output.get("hookSpecificOutput", {})
+    assert hook_output.get("permissionDecision") == "allow", (
+        f"Expected permissionDecision 'allow', got: {output}"
+    )
 
 
 def assert_blocked(code, output, reason_substring=""):
-    """Assert that the hook blocked the operation (PreToolUse)."""
+    """Assert that the hook denied the operation (PreToolUse).
+
+    Valid deny format: hookSpecificOutput.permissionDecision = "deny"
+    """
     assert code == 0, f"Expected exit 0, got {code}"
-    assert output.get("continue") is False
     hook_output = output.get("hookSpecificOutput", {})
-    assert hook_output.get("permissionDecision") == "block"
+    assert hook_output.get("permissionDecision") == "deny", (
+        f"Expected permissionDecision 'deny', got: {output}"
+    )
     if reason_substring:
         assert reason_substring in hook_output.get("permissionDecisionReason", "")
 
@@ -133,22 +143,23 @@ class TestModernOutputFormat:
 
     def test_exit_warn_outputs_valid_json(self):
         _, output, _ = self._run_common_func("exit_warn", "test warning")
+        # Without event_name, uses generic format with systemMessage
         assert output.get("continue") is True
         assert output.get("suppressOutput") is False
-        assert output.get("additionalContext") == "test warning"
+        assert output.get("systemMessage") == "test warning"
 
     # -- exit_block --
 
     def test_exit_block_outputs_valid_json(self):
         _, output, _ = self._run_common_func("exit_block", "test block")
-        assert output.get("continue") is False
-        assert output.get("suppressOutput") is False
+        hook_output = output.get("hookSpecificOutput", {})
+        assert hook_output.get("permissionDecision") == "deny"
 
     def test_exit_block_includes_hook_specific_output(self):
         _, output, _ = self._run_common_func("exit_block", "reason here")
         hook_output = output.get("hookSpecificOutput", {})
         assert hook_output["hookEventName"] == "PreToolUse"
-        assert hook_output["permissionDecision"] == "block"
+        assert hook_output["permissionDecision"] == "deny"
         assert hook_output["permissionDecisionReason"] == "reason here"
 
     # -- exit_stop_allow --
@@ -269,8 +280,9 @@ class TestSubagentFindingsCheck:
 
     SubagentStop hooks use Stop protocol:
     - Allow: no output (empty stdout, exit 0)
-    - Warn: {"decision": "approve", "reason": msg}
+    - Warn: {"systemMessage": msg}
     - Block: {"decision": "block", "reason": msg}
+    See: https://code.claude.com/docs/en/hooks
     """
 
     def test_allows_empty_message(self):
@@ -305,9 +317,9 @@ class TestSubagentFindingsCheck:
         }
         code, output, _ = run_hook("subagent_findings_check.py", event)
         assert code == 0
-        assert output.get("decision") == "approve"
-        assert "WARNING" in output.get("reason", "")
-        assert "PUNCHLIST.md" in output.get("reason", "")
+        assert "systemMessage" in output
+        assert "WARNING" in output.get("systemMessage", "")
+        assert "PUNCHLIST.md" in output.get("systemMessage", "")
 
     def test_deduplicates_paths(self, tmp_path):
         """Multiple references to the same path should be deduplicated."""
@@ -317,9 +329,9 @@ class TestSubagentFindingsCheck:
         }
         code, output, _ = run_hook("subagent_findings_check.py", event)
         assert code == 0
-        assert output.get("decision") == "approve"
+        assert "systemMessage" in output
         # Should only mention FOO.md once
-        assert output.get("reason", "").count("FOO.md") == 1
+        assert output.get("systemMessage", "").count("FOO.md") == 1
 
     def test_warns_missing_json_artifacts(self, tmp_path):
         """BH-007: .json artifacts under docs/holtz/ should be checked, not just .md."""
@@ -329,9 +341,9 @@ class TestSubagentFindingsCheck:
         }
         code, output, _ = run_hook("subagent_findings_check.py", event)
         assert code == 0
-        assert output.get("decision") == "approve"
-        assert "WARNING" in output.get("reason", "")
-        assert "impact-graph.json" in output.get("reason", "")
+        assert "systemMessage" in output
+        assert "WARNING" in output.get("systemMessage", "")
+        assert "impact-graph.json" in output.get("systemMessage", "")
 
     def test_allows_existing_json_artifact(self, tmp_path):
         """BH-007: existing .json artifact should be allowed."""
@@ -392,14 +404,14 @@ class TestSubagentFindingsCheckInProcess:
         assert output == {}
 
     def test_missing_md_warns(self, tmp_path, capsys):
-        """Missing file → stop-warn with decision=approve."""
+        """Missing file → stop-warn with systemMessage."""
         event = {
             "last_assistant_message": "Wrote docs/holtz/NONEXISTENT.md",
             "cwd": str(tmp_path),
         }
         output = self._run_main(event, capsys)
-        assert output.get("decision") == "approve"
-        assert "NONEXISTENT.md" in output.get("reason", "")
+        assert "systemMessage" in output
+        assert "NONEXISTENT.md" in output.get("systemMessage", "")
 
     def test_existing_file_ok(self, tmp_path, capsys):
         """Existing file → stop-allow (no output)."""
@@ -414,14 +426,14 @@ class TestSubagentFindingsCheckInProcess:
         assert output == {}
 
     def test_json_artifact_warns(self, tmp_path, capsys):
-        """Missing JSON artifact → stop-warn with decision=approve."""
+        """Missing JSON artifact → stop-warn with systemMessage."""
         event = {
             "last_assistant_message": "Updated docs/holtz/impact-graph.json",
             "cwd": str(tmp_path),
         }
         output = self._run_main(event, capsys)
-        assert output.get("decision") == "approve"
-        assert "impact-graph.json" in output.get("reason", "")
+        assert "systemMessage" in output
+        assert "impact-graph.json" in output.get("systemMessage", "")
 
 
 # --- _common.py in-process coverage for exit_stop_warn, exit_stop_block, read_event ---
@@ -471,16 +483,16 @@ class TestCommonInProcess:
         result = common.read_event()
         assert result == {"tool_name": "Bash", "args": {}}
 
-    def test_exit_stop_warn_outputs_approve_decision(self, capsys):
-        """exit_stop_warn outputs decision=approve with reason (lines 163-167)."""
+    def test_exit_stop_warn_outputs_system_message(self, capsys):
+        """exit_stop_warn outputs systemMessage (allows stop, shows msg to user)."""
         import contextlib
         common = self._import_common()
         with contextlib.suppress(SystemExit):
             common.exit_stop_warn("config not found")
         captured = capsys.readouterr()
         output = json.loads(captured.out)
-        assert output["decision"] == "approve"
-        assert output["reason"] == "config not found"
+        assert output["systemMessage"] == "config not found"
+        assert "decision" not in output
 
     def test_exit_stop_block_outputs_block_decision(self, capsys):
         """exit_stop_block outputs decision=block with reason (lines 177-181)."""

--- a/tests/test_impact_graph.py
+++ b/tests/test_impact_graph.py
@@ -743,24 +743,24 @@ def test_cli_add_node_and_stats(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_neighbors_empty_types_is_no_filter(graph):
-    """neighbors with types=[] is falsy → treated as no filter, returns all (BH-005)."""
+def test_neighbors_empty_types_returns_empty(graph):
+    """neighbors with types=[] means 'match no edge types' → returns empty."""
     graph.add_node("solo.py::A", "function", "solo.py", line=1)
     graph.add_node("solo.py::B", "function", "solo.py", line=5)
     graph.add_edge("solo.py::A", "solo.py::B", "calls")
 
-    # [] is falsy in Python → type_set = None → no filter → all neighbors returned
-    assert graph.neighbors("solo.py::A", types=[]) == ["solo.py::B"]
+    # types=[] is an explicit empty set → no types match → no neighbors
+    assert graph.neighbors("solo.py::A", types=[]) == []
 
 
-def test_blast_radius_empty_types_is_no_filter(graph):
-    """blast_radius with types=[] is falsy → treated as no filter, returns all (BH-005)."""
+def test_blast_radius_empty_types_returns_empty(graph):
+    """blast_radius with types=[] means 'match no edge types' → returns empty."""
     graph.add_node("void.py::A", "function", "void.py", line=1)
     graph.add_node("void.py::B", "function", "void.py", line=5)
     graph.add_edge("void.py::A", "void.py::B", "calls")
 
-    # [] is falsy → type_set = None → no filter → all reachable
-    assert graph.blast_radius("void.py::A", depth=2, types=[]) == ["void.py::B"]
+    # types=[] is an explicit empty set → no types match → no reachable nodes
+    assert graph.blast_radius("void.py::A", depth=2, types=[]) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_primer.py
+++ b/tests/test_primer.py
@@ -51,9 +51,9 @@ class TestPrimerTerminatedAudit:
         event = {"cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("primer.py", event, cwd=str(tmp_path))
         assert code == 0
-        # Primer uses exit_warn, so continue=True, suppressOutput=False
-        assert output.get("continue") is True
-        context = output.get("additionalContext", "")
+        # Primer uses exit_warn with "UserPromptSubmit" → hookSpecificOutput
+        hook_output = output.get("hookSpecificOutput", {})
+        context = hook_output.get("additionalContext", "")
         assert "AUDIT TERMINATED" in context
 
     def test_no_restart_attempt_on_socket_failure(self, tmp_path):
@@ -86,7 +86,8 @@ class TestPrimerAuthFailureFailClosed:
         event = {"cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("primer.py", event, cwd=str(tmp_path))
         assert code == 0
-        context = output.get("additionalContext", "")
+        hook_output = output.get("hookSpecificOutput", {})
+        context = hook_output.get("additionalContext", "")
         assert "ENFORCEMENT FAILURE" in context
         assert "STOP" in context
 

--- a/tests/test_primer.py
+++ b/tests/test_primer.py
@@ -12,7 +12,6 @@ sys.path.insert(0, os.path.join(REPO_ROOT, "enforcement", "hooks"))
 sys.path.insert(0, os.path.join(REPO_ROOT, "tests"))
 
 from _resolve import ensure_sahjhan  # noqa: E402
-
 from test_sahjhan_integration import run_enforcement_hook  # noqa: E402
 
 SAHJHAN = ensure_sahjhan()

--- a/tests/test_protocol_enforcement.py
+++ b/tests/test_protocol_enforcement.py
@@ -50,9 +50,9 @@ class TestPreToolHookFailClosed:
             "pre_tool_hook.py", event, cwd=str(tmp_path), env=env,
         )
         assert code == 0
-        assert output.get("continue") is False
-        reason = output.get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
-        assert "ENFORCEMENT DEGRADED" in reason
+        hook_output = output.get("hookSpecificOutput", {})
+        assert hook_output.get("permissionDecision") == "deny"
+        assert "ENFORCEMENT DEGRADED" in hook_output.get("permissionDecisionReason", "")
 
     def test_allows_when_binary_unavailable_and_stale(self, tmp_path, mock_daemon):
         """Sahjhan binary missing + stale enforcement → allow."""
@@ -76,7 +76,7 @@ class TestPreToolHookFailClosed:
             "pre_tool_hook.py", event, cwd=str(tmp_path), env=env,
         )
         assert code == 0
-        assert output.get("continue") is True
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
 
     def test_allows_when_binary_unavailable_and_no_audit(self, tmp_path):
         """Sahjhan binary missing + no active audit → allow."""
@@ -93,7 +93,7 @@ class TestPreToolHookFailClosed:
             "pre_tool_hook.py", event, cwd=str(tmp_path), env=env,
         )
         assert code == 0
-        assert output.get("continue") is True
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
 
 
 class TestProtocolCache:
@@ -638,7 +638,7 @@ class TestCommitGate:
         code, output, _ = run_enforcement_hook("commit_gate.py", event)
         assert code == 0
         perm = output.get("hookSpecificOutput", {}).get("permissionDecision")
-        assert perm == "block"
+        assert perm == "deny"
         reason = output.get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
         assert "unregistered" in reason.lower() or "fix_commit" in reason.lower()
 
@@ -694,7 +694,7 @@ class TestCommitGate:
         code, output, _ = run_enforcement_hook("commit_gate.py", event)
         assert code == 0
         perm = output.get("hookSpecificOutput", {}).get("permissionDecision")
-        assert perm == "block"
+        assert perm == "deny"
 
     def test_blocks_commit_when_pattern_overdue(self, tmp_path, mock_daemon):
         """Pattern check overdue hard-blocks git commit after 3+ fixes."""
@@ -714,7 +714,7 @@ class TestCommitGate:
         code, output, _ = run_enforcement_hook("commit_gate.py", event)
         assert code == 0
         perm = output.get("hookSpecificOutput", {}).get("permissionDecision")
-        assert perm == "block"
+        assert perm == "deny"
         reason = output.get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
         assert "pattern" in reason.lower()
 
@@ -736,8 +736,8 @@ class TestCommitGate:
         code, output, _ = run_enforcement_hook("commit_gate.py", event)
         assert code == 0
         # Non-commit commands should get soft injection, not blocked
-        assert output.get("continue") is True
-        context = output.get("additionalContext", "")
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
+        context = output.get("hookSpecificOutput", {}).get("additionalContext", "")
         assert "pattern_check" in context.lower()
 
     def test_allows_sahjhan_when_pattern_overdue(self, tmp_path, mock_daemon):
@@ -828,7 +828,7 @@ class TestEnforcementIntegration:
         }
         code, output, _ = run_enforcement_hook("commit_gate.py", gate_event)
         perm = output.get("hookSpecificOutput", {}).get("permissionDecision")
-        assert perm == "block", "Gate should block second commit"
+        assert perm == "deny", "Gate should block second commit"
 
         # But: sahjhan command is allowed
         sahjhan_event = {
@@ -858,7 +858,7 @@ class TestEnforcementIntegration:
         }
         code, output, _ = run_enforcement_hook("commit_gate.py", event)
         perm = output.get("hookSpecificOutput", {}).get("permissionDecision")
-        assert perm == "block"
+        assert perm == "deny"
 
         # Sahjhan allowed
         event["tool_input"]["command"] = "./bin/sahjhan status"
@@ -896,7 +896,7 @@ class TestEnforcementIntegration:
             "tool_input": {"command": "git commit -m 'fix: second'"},
             "cwd": str(tmp_path),
         })
-        assert out.get("hookSpecificOutput", {}).get("permissionDecision") == "block"
+        assert out.get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
 
         # 4. Simulate sahjhan fix_commit (tracker clears unregistered)
         run_enforcement_hook("protocol_tracker.py", {
@@ -1050,8 +1050,9 @@ class TestStopHookFreshness:
         event = {"cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("stop_hook.py", event)
         assert code == 0
-        assert output.get("decision") == "approve"
-        assert "stale" in output.get("reason", "").lower() or "abandoned" in output.get("reason", "").lower()
+        assert "systemMessage" in output
+        msg = output.get("systemMessage", "").lower()
+        assert "stale" in msg or "abandoned" in msg
 
     def test_allows_stop_in_terminal_state(self, tmp_path, mock_daemon):
         """Terminal state (finalized) → allow stop regardless of freshness."""
@@ -1097,13 +1098,14 @@ class TestStopHookFreshness:
         event = {"cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("stop_hook.py", event)
         assert code == 0
-        # Was "block" (issue #29 R5), now "approve" with warning (issue #48)
-        assert output.get("decision") == "approve", (
+        # Was "block" (issue #29 R5), now warn with systemMessage (issue #48)
+        assert "systemMessage" in output, (
             f"Missing both caches should warn, not block (issue #48 bug 1), got: {output}"
         )
-        reason = output.get("reason", "").lower()
-        assert "unavailable" in reason or "status-cache" in reason, (
-            f"Warn reason should mention 'unavailable' or 'status-cache', got: {output.get('reason')}"
+        assert "decision" not in output, f"Warn should not have decision field, got: {output}"
+        msg = output.get("systemMessage", "").lower()
+        assert "unavailable" in msg or "status-cache" in msg, (
+            f"Warn message should mention 'unavailable' or 'status-cache', got: {output.get('systemMessage')}"
         )
 
     def test_block_message_includes_state(self, tmp_path, mock_daemon):
@@ -1268,7 +1270,6 @@ class TestExitEnforcementError:
 
         assert exc_info.value.code == 0
         output = json.loads(capsys.readouterr().out)
-        assert output["continue"] is False
         reason = output["hookSpecificOutput"]["permissionDecisionReason"]
         assert "ENFORCEMENT DEGRADED" in reason
         assert "daemon unreachable" in reason
@@ -1295,8 +1296,8 @@ class TestExitEnforcementError:
 
         assert exc_info.value.code == 0
         output = json.loads(capsys.readouterr().out)
-        assert output["continue"] is True
-        assert "ENFORCEMENT DEGRADED" in output["additionalContext"]
+        hook_output = output.get("hookSpecificOutput", {})
+        assert "ENFORCEMENT DEGRADED" in hook_output.get("additionalContext", "")
 
     def test_allows_when_no_active_audit(self, tmp_path, capsys):
         """No .sahjhan dir → allow (fail-open)."""
@@ -1311,7 +1312,7 @@ class TestExitEnforcementError:
 
         assert exc_info.value.code == 0
         output = json.loads(capsys.readouterr().out)
-        assert output["continue"] is True
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
 
     def test_allows_when_stale_enforcement(self, tmp_path, mock_daemon, capsys):
         """Active audit but stale enforcement → allow (fail-open)."""
@@ -1334,7 +1335,7 @@ class TestExitEnforcementError:
 
         assert exc_info.value.code == 0
         output = json.loads(capsys.readouterr().out)
-        assert output["continue"] is True
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
 
     def test_allows_when_sahjhan_dir_but_no_cache(self, tmp_path, capsys):
         """Data dir exists but no cache file → allow (fail-open)."""
@@ -1353,7 +1354,7 @@ class TestExitEnforcementError:
 
         assert exc_info.value.code == 0
         output = json.loads(capsys.readouterr().out)
-        assert output["continue"] is True
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
 
 
 class TestProtocolTrackerDaemonTeardown:
@@ -1565,7 +1566,7 @@ class TestRemainingHooksFreshness:
         code, output, _ = run_enforcement_hook("pre_tool_hook.py", event)
         assert code == 0
         perm = output.get("hookSpecificOutput", {}).get("permissionDecision")
-        assert perm == "block"
+        assert perm == "deny"
 
     def test_post_tool_hook_exits_early_when_stale(self, tmp_path, mock_daemon):
         """Stale enforcement → post_tool_hook does nothing."""
@@ -1658,8 +1659,8 @@ class TestPostToolHookFailClosed:
             "post_tool_hook.py", event, cwd=str(tmp_path), env=env,
         )
         assert code == 0
-        assert output.get("continue") is True
-        assert "ENFORCEMENT DEGRADED" in output.get("additionalContext", "")
+        assert "hookSpecificOutput" in output
+        assert "ENFORCEMENT DEGRADED" in output.get("hookSpecificOutput", {}).get("additionalContext", "")
 
     def test_silent_allow_when_stale(self, tmp_path, mock_daemon):
         """Stale enforcement → silent allow (no warning)."""
@@ -1741,8 +1742,8 @@ class TestBashGuardFailClosed:
             "bash_guard.py", event, cwd=str(tmp_path), env=env,
         )
         assert code == 0
-        assert output.get("continue") is True
-        assert "ENFORCEMENT DEGRADED" in output.get("additionalContext", "")
+        assert "hookSpecificOutput" in output
+        assert "ENFORCEMENT DEGRADED" in output.get("hookSpecificOutput", {}).get("additionalContext", "")
 
     def test_silent_allow_when_no_audit(self, tmp_path):
         """No active audit → silent allow."""

--- a/tests/test_protocol_enforcement.py
+++ b/tests/test_protocol_enforcement.py
@@ -1177,6 +1177,7 @@ class TestStopHookDaemonCleanupGating:
         from unittest.mock import patch
 
         import pytest
+
         from _protocol_cache import empty_cache, write_cache
 
         cache = empty_cache()
@@ -1201,6 +1202,7 @@ class TestStopHookDaemonCleanupGating:
         from unittest.mock import patch
 
         import pytest
+
         from _protocol_cache import empty_cache, write_cache
 
         cache = empty_cache()
@@ -1226,6 +1228,7 @@ class TestStopHookDaemonCleanupGating:
         from unittest.mock import patch
 
         import pytest
+
         from _protocol_cache import empty_cache, write_cache
 
         cache = empty_cache()
@@ -1254,9 +1257,9 @@ class TestExitEnforcementError:
         from datetime import datetime, timezone  # noqa: UP017
 
         import pytest
-        from _protocol_cache import empty_cache, write_cache
 
         from _common import exit_enforcement_error
+        from _protocol_cache import empty_cache, write_cache
 
         sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
         sahjhan_dir.mkdir(parents=True, exist_ok=True)
@@ -1280,9 +1283,9 @@ class TestExitEnforcementError:
         from datetime import datetime, timezone  # noqa: UP017
 
         import pytest
-        from _protocol_cache import empty_cache, write_cache
 
         from _common import exit_enforcement_error
+        from _protocol_cache import empty_cache, write_cache
 
         sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
         sahjhan_dir.mkdir(parents=True, exist_ok=True)
@@ -1319,9 +1322,9 @@ class TestExitEnforcementError:
         import json
 
         import pytest
-        from _protocol_cache import empty_cache, write_cache
 
         from _common import exit_enforcement_error
+        from _protocol_cache import empty_cache, write_cache
 
         sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
         sahjhan_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_sahjhan_integration.py
+++ b/tests/test_sahjhan_integration.py
@@ -42,16 +42,17 @@ def run_enforcement_hook(hook_name, event, cwd=None, env=None):
 def assert_allowed(code, output):
     """Assert that a PreToolUse hook allowed the operation."""
     assert code == 0, f"Expected exit 0, got {code}"
-    assert output.get("continue") is True
-    assert output.get("suppressOutput") is True
+    hook_output = output.get("hookSpecificOutput", {})
+    assert hook_output.get("permissionDecision") == "allow", (
+        f"Expected permissionDecision 'allow', got: {output}"
+    )
 
 
 def assert_blocked(code, output, reason_substring=""):
     """Assert that a PreToolUse hook blocked the operation."""
     assert code == 0, f"Expected exit 0, got {code}"
-    assert output.get("continue") is False
     hook_output = output.get("hookSpecificOutput", {})
-    assert hook_output.get("permissionDecision") == "block", (
+    assert hook_output.get("permissionDecision") == "deny", (
         f"Expected block, got: {hook_output}"
     )
     if reason_substring:
@@ -542,7 +543,7 @@ class TestBashGuard:
         # Should get the warning (manifest failed) since chained cmd is not pure sahjhan
         assert code == 0
         # exit_warn puts the message in additionalContext, not hookSpecificOutput
-        assert "PROTOCOL VIOLATION" in output.get("additionalContext", ""), (
+        assert "PROTOCOL VIOLATION" in output.get("hookSpecificOutput", {}).get("additionalContext", ""), (
             "Expected PROTOCOL VIOLATION warning for non-pure-sahjhan chained command"
         )
 
@@ -771,7 +772,7 @@ class TestPrimer:
         assert (sahjhan_dir / "terminated").exists(), (
             "primer should write terminated marker when init PID is dead"
         )
-        context = output.get("additionalContext", "")
+        context = output.get("hookSpecificOutput", {}).get("additionalContext", "")
         assert "AUDIT TERMINATED" in context, (
             "primer should inject termination message"
         )
@@ -916,7 +917,7 @@ class TestBashGuardWithMockBinary:
         )
         assert code == 0
         # exit_warn puts the message in additionalContext
-        assert "PROTOCOL VIOLATION" in output.get("additionalContext", "")
+        assert "PROTOCOL VIOLATION" in output.get("hookSpecificOutput", {}).get("additionalContext", "")
 
 
 class TestPrimerWithMockBinary:
@@ -964,9 +965,9 @@ class TestPrimerWithMockBinary:
             "primer.py", event, cwd=str(tmp_path), env=_mock_env(tmp_path)
         )
         assert code == 0
-        assert output.get("continue") is True
+        assert "hookSpecificOutput" in output
         # exit_warn puts resume context in additionalContext
-        context = output.get("additionalContext", "")
+        context = output.get("hookSpecificOutput", {}).get("additionalContext", "")
         assert "fix_loop" in context
 
     def test_silent_for_terminal_state(self, tmp_path, mock_daemon):
@@ -979,7 +980,7 @@ class TestPrimerWithMockBinary:
         assert code == 0
         # Terminal state = exit_ok, no additionalContext
         assert output.get("continue") is True
-        assert "additionalContext" not in output
+        assert "additionalContext" not in output.get("hookSpecificOutput", {})
 
     def test_injects_lens_priming_in_audit(self, tmp_path, mock_daemon):
         """Primer injects lens priming when in audit state with active perspective."""
@@ -995,7 +996,7 @@ class TestPrimerWithMockBinary:
         code, output, _ = run_enforcement_hook(
             "primer.py", event, cwd=str(tmp_path), env=_mock_env(tmp_path)
         )
-        context = output.get("additionalContext", "")
+        context = output.get("hookSpecificOutput", {}).get("additionalContext", "")
         assert "audit" in context
 
     def test_warns_when_context_reset_fails(self, tmp_path, mock_daemon):
@@ -1020,7 +1021,7 @@ class TestPrimerWithMockBinary:
         code, output, _ = run_enforcement_hook(
             "primer.py", event, cwd=str(tmp_path), env=env
         )
-        context = output.get("additionalContext", "")
+        context = output.get("hookSpecificOutput", {}).get("additionalContext", "")
         # Must still inject resume context
         assert "awaiting_clear" in context
         # Must inject hard stop instruction on auth failure (issue #45)

--- a/tests/test_stop_hook.py
+++ b/tests/test_stop_hook.py
@@ -151,12 +151,13 @@ class TestStopHookStatusCacheFallback:
 
         assert code == 0
         # Should warn, not block — blocking creates infinite loop
-        assert output.get("decision") == "approve", (
+        assert "systemMessage" in output, (
             f"Missing both caches should warn (not block) to avoid infinite loop, got: {output}"
         )
-        reason = output.get("reason", "").lower()
-        assert "unavailable" in reason or "status-cache" in reason, (
-            f"Warn reason should mention 'unavailable' or 'status-cache', got: {output.get('reason')}"
+        assert "decision" not in output, f"Warn should not have decision field, got: {output}"
+        msg = output.get("systemMessage", "").lower()
+        assert "unavailable" in msg or "status-cache" in msg, (
+            f"Warn message should mention 'unavailable' or 'status-cache', got: {output.get('systemMessage')}"
         )
 
 

--- a/tests/test_verify_hooks.py
+++ b/tests/test_verify_hooks.py
@@ -63,6 +63,7 @@ def test_passes_with_all_hooks(tmp_path):
         "SubagentStop": [
             {"matcher": "", "hooks": [
                 {"type": "command", "command": "python enforcement/hooks/lens_quiz.py"},
+                {"type": "command", "command": "python hooks/subagent_findings_check.py"},
             ]},
         ],
     }


### PR DESCRIPTION
## Summary

- **Security: 3 bootstrap write-protection bypasses closed** — `cp -t`, `mv -t`, and full-path commands (`/bin/cp`, `/bin/rm`) could write to protected enforcement paths. Now handles target-directory flags and extracts command basenames.
- **CI: enforcement hooks added to coverage, mypy, and ruff** — the 14 most security-critical Python files were excluded from all three quality gates. Coverage with enforcement: 70.6%.
- **Stale references fixed** — quiz-bank.json pointed to deleted `write_guard.py`/`stop_gate.py`, settings example was severely outdated, README described a removed read guard feature.
- **Semantic bug in impact_graph** — `types=[]` treated as "no filter" instead of "match nothing" due to Python falsy empty list. Test asserted the wrong behavior.
- **Content truncation in pattern_brief** — field extraction regex terminated at any bold markdown, sentence splitting broke on filenames like `config.json`.
- **Hook schema as single source of truth** — new `hook_schema.py` module with E2E validators, freshness gate against live Claude Code docs.
- **9 other fixes**: changelog double-counting, viewer XSS, vendor-sahjhan silent HTTP errors, smoke-test skip counting, lens registry parser crash on non-lens sections, and more.

Full changelog: [CHANGELOG.md](CHANGELOG.md)

## Test plan

- [x] 1175 tests pass (up from 1166)
- [x] `ruff check .` clean
- [x] `mypy --explicit-package-bases skills/holtz/scripts/ hooks/ enforcement/hooks/` clean
- [x] Coverage with enforcement hooks: 70.6% (gate: 60%)
- [x] Schema freshness gate passes (`test_hook_schema_freshness.py`)
- [x] Bootstrap bypass regression tests: `cp -t`, `mv -t`, `/bin/cp`, `/bin/rm` all blocked
- [x] E2E hook chain tests pass for all 5 event types

🤖 Generated with [Claude Code](https://claude.com/claude-code)