### PR TITLE
chore: release v0.138.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.138.0",
+  "version": "0.138.1",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.138.1] - 2026-07-21
+
+_Changes since v0.138.0_
+
+### Fixed
+- **enforcement:** read Bash stdout from tool_response.stdout (#75)
+
 ## [0.138.0] - 2026-07-17
 
 _Changes since v0.137.2_

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/jbrjake/holtz/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/jbrjake/holtz/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)
-![1749 tests](https://img.shields.io/badge/tests-1749_total-brightgreen.svg)
+![1761 tests](https://img.shields.io/badge/tests-1761_total-brightgreen.svg)
 ![91% coverage](https://img.shields.io/badge/coverage-91%25-brightgreen.svg)
 
 **Adversarial TDD audit loop for Claude Code.** Dual auditors find bugs, write failing tests, fix them, and repeat until two consecutive passes find nothing new.

--- a/enforcement/hooks/_common.py
+++ b/enforcement/hooks/_common.py
@@ -35,6 +35,8 @@ _spec.loader.exec_module(_mod)
 # exit helpers and lets callers' narrowing silently disappear. Annotate
 # the re-exports so mypy knows these never return.
 read_event: Callable[..., dict] = _mod.read_event
+bash_output: Callable[[dict], str] = _mod.bash_output
+bash_exit_code: Callable[[dict], int] = _mod.bash_exit_code
 exit_ok: Callable[..., NoReturn] = _mod.exit_ok
 exit_warn: Callable[..., NoReturn] = _mod.exit_warn
 exit_block: Callable[[str], NoReturn] = _mod.exit_block

--- a/enforcement/hooks/protocol_tracker.py
+++ b/enforcement/hooks/protocol_tracker.py
@@ -15,7 +15,13 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from _common import exit_ok, read_event, resolve_config_dir  # noqa: E402
+from _common import (  # noqa: E402
+    bash_exit_code,
+    bash_output,
+    exit_ok,
+    read_event,
+    resolve_config_dir,
+)
 from _protocol_cache import (  # noqa: E402
     contains_sahjhan_cmd,
     empty_cache,
@@ -160,8 +166,11 @@ def main() -> None:
 
     cwd = event.get("cwd", os.getcwd())
     cmd = event.get("tool_input", {}).get("command", "")
-    exit_code = event.get("tool_response", {}).get("exit_code", -1)
-    output = event.get("tool_response", {}).get("output", "")
+    # CC 2.x Bash payloads carry stdout under .stdout and omit exit_code
+    # (PostToolUse fires only on success); the helpers read both shapes so
+    # git-commit registration below doesn't silently die on 2.x (#75).
+    exit_code = bash_exit_code(event)
+    output = bash_output(event)
 
     cache = read_cache(cwd)
 

--- a/enforcement/hooks/quiz_capture.py
+++ b/enforcement/hooks/quiz_capture.py
@@ -26,7 +26,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from _common import exit_ok, exit_warn, read_event  # noqa: E402
+from _common import bash_output, exit_ok, exit_warn, read_event  # noqa: E402
 from lens_quiz import verify_answer_freshness  # noqa: E402
 from quiz_vault import (  # noqa: E402
     append_question,
@@ -46,7 +46,10 @@ def main() -> None:
     if event.get("tool_name") != "Bash":
         exit_ok()
 
-    output = event.get("tool_response", {}).get("output", "") or ""
+    # Read stdout via the shape-tolerant helper: CC 2.x puts Bash stdout under
+    # tool_response.stdout, not .output — reading .output silently dropped every
+    # staged question and wedged recon_complete (#75).
+    output = bash_output(event)
     if QUESTION_MARKER not in output and FINALIZE_MARKER not in output:
         exit_ok()
 

--- a/enforcement/trusted-callers.toml
+++ b/enforcement/trusted-callers.toml
@@ -11,7 +11,7 @@
 # CI gate: the pre-commit hook verifies this manifest is up to date.
 
 [callers]
-"hooks/_common.py" = "sha256:58be4d01b1e1297e8f1cb1a247afabe6feecc75ae96713c9fc17085bf87f0977"
+"hooks/_common.py" = "sha256:6e2a731ad0a23d4c685d073707ebf28167d7da0f7de13600b0a86fc2e7a876d8"
 "hooks/lens_quiz.py" = "sha256:adcdf6336412dcc1e3dd8f3d181362c37cf84ec2f8e83cbeaadbe486a05eb991"
 "hooks/stop_hook.py" = "sha256:1c8645eb0610db19dee54c0ffa43a64073c994dd926053215018434e54af2653"
 "hooks/primer.py" = "sha256:cc933b70db32c93dc3b1b257f056f61d0ca7a99ba3f140929e1954eee010fcff"
@@ -19,6 +19,6 @@
 "hooks/post_tool_hook.py" = "sha256:63e513159f24f79c3d23bac2d30a77e315b9905c578472dde0329e52c1918947"
 "hooks/commit_gate.py" = "sha256:e1b26fae9dace0e9556fdad292eb34e102b2a3f03d705beaed4e28145458b840"
 "hooks/bash_guard.py" = "sha256:a534dca9da6509d573c25965dda2c29d7cd2196cd8486a1837d0965f6d5e5a09"
-"hooks/protocol_tracker.py" = "sha256:d573eb5d7d13252bb09bf6742365c44389a79381f9a198fad49b975cb4a8b165"
-"hooks/quiz_capture.py" = "sha256:410ee67531c98da4ca570f47283a4fc4d199d8846d0b24abb2917045283d04a3"
+"hooks/protocol_tracker.py" = "sha256:2140adb5c0e90fd9540293754630541cdddaf900de065afe22fd622abef519fa"
+"hooks/quiz_capture.py" = "sha256:3d1697849e6a9a313f29bb9745c1181ba69a31258eec27f4bb84b65afe0484aa"
 "hooks/subagent_findings_check.py" = "sha256:f97d12f1d431dad0f9a88ea25c24e923acb3d0a6f4722c0bfb4d047fb161d921"

--- a/hooks/_common.py
+++ b/hooks/_common.py
@@ -42,6 +42,37 @@ def read_event() -> dict[str, Any]:
         return {}
 
 
+def bash_output(event: dict[str, Any]) -> str:
+    """Return a Bash tool's stdout from a PostToolUse event, shape-tolerant.
+
+    Claude Code 2.x delivers Bash stdout under ``tool_response.stdout``
+    (verified on 2.1.x: the payload is
+    ``{"stdout", "stderr", "interrupted", "isImage", "noOutputExpected"}``
+    with no ``output`` key). Pre-2.x payloads used ``tool_response.output``.
+    A hook that reads only ``output`` silently sees ``""`` on 2.x — the #75
+    failure that left the lens-quiz vault empty and wedged ``recon_complete``.
+
+    Read ``stdout`` first, fall back to ``output`` so both shapes work.
+    """
+    tr = event.get("tool_response") or {}
+    return tr.get("stdout") or tr.get("output") or ""
+
+
+def bash_exit_code(event: dict[str, Any]) -> int:
+    """Return a Bash tool's exit code from a PostToolUse event, shape-tolerant.
+
+    Claude Code 2.x omits ``exit_code`` entirely and fires PostToolUse only
+    *after a tool call succeeds* (a non-zero Bash exit does not fire the
+    event at all — verified on 2.1.x). So an absent code means success: it
+    defaults to ``0`` rather than a sentinel, otherwise every 2.x commit
+    would fail the ``exit_code == 0`` guard and never register (#75). Pre-2.x
+    payloads carry an explicit ``exit_code`` (possibly non-zero); honor it.
+    """
+    tr = event.get("tool_response") or {}
+    code = tr.get("exit_code")
+    return 0 if code is None else int(code)
+
+
 def exit_ok(event_name: str = "") -> NoReturn:
     """Allow the tool call silently, exit 0.
 

--- a/tests/test_bash_payload_helpers.py
+++ b/tests/test_bash_payload_helpers.py
@@ -1,0 +1,79 @@
+"""Unit tests for the shape-tolerant Bash PostToolUse helpers (#75).
+
+``hooks/_common.bash_output`` / ``bash_exit_code`` decouple the enforcement
+hooks from Claude Code payload-shape drift. Claude Code 2.x delivers Bash
+stdout under ``tool_response.stdout`` and omits ``exit_code`` entirely; pre-2.x
+used ``tool_response.output`` with an explicit ``exit_code``. Reading only the
+pre-2.x keys is what wedged ``recon_complete`` in #75, so these tests pin both
+shapes.
+
+The exact 2.x payload below was captured live from Claude Code 2.1.x:
+
+    "tool_response": {"stdout": "...", "stderr": "", "interrupted": false,
+                      "isImage": false, "noOutputExpected": false}
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# Load hooks/_common.py under a unique module name so we don't pollute
+# sys.modules['_common'] (the enforcement hooks import the bare name and a
+# cached hooks version breaks them under some collection orderings).
+_path = Path(__file__).resolve().parent.parent / "hooks" / "_common.py"
+_spec = importlib.util.spec_from_file_location("_hooks_common_for_bash_test", str(_path))
+if _spec is None or _spec.loader is None:
+    raise RuntimeError(f"Cannot load {_path}")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+bash_output = _mod.bash_output
+bash_exit_code = _mod.bash_exit_code
+
+
+def _cc2x(stdout: str) -> dict:
+    """The real Claude Code 2.x Bash PostToolUse tool_response shape."""
+    return {
+        "tool_response": {
+            "stdout": stdout,
+            "stderr": "",
+            "interrupted": False,
+            "isImage": False,
+            "noOutputExpected": False,
+        }
+    }
+
+
+class TestBashOutput:
+    def test_reads_cc2x_stdout(self):
+        assert bash_output(_cc2x("hello")) == "hello"
+
+    def test_reads_legacy_output(self):
+        assert bash_output({"tool_response": {"exit_code": 0, "output": "hi"}}) == "hi"
+
+    def test_prefers_stdout_over_output(self):
+        event = {"tool_response": {"stdout": "new", "output": "old"}}
+        assert bash_output(event) == "new"
+
+    def test_missing_tool_response_is_empty(self):
+        assert bash_output({}) == ""
+
+    def test_none_tool_response_is_empty(self):
+        assert bash_output({"tool_response": None}) == ""
+
+    def test_no_stdout_no_output_is_empty(self):
+        assert bash_output(_cc2x("")) == ""
+
+
+class TestBashExitCode:
+    def test_absent_defaults_to_success(self):
+        # CC 2.x omits exit_code and only fires PostToolUse on success.
+        assert bash_exit_code(_cc2x("ok")) == 0
+
+    def test_explicit_zero(self):
+        assert bash_exit_code({"tool_response": {"exit_code": 0, "output": ""}}) == 0
+
+    def test_explicit_nonzero_is_honored(self):
+        assert bash_exit_code({"tool_response": {"exit_code": 1, "output": ""}}) == 1
+
+    def test_missing_tool_response_defaults_to_success(self):
+        assert bash_exit_code({}) == 0

--- a/tests/test_protocol_enforcement.py
+++ b/tests/test_protocol_enforcement.py
@@ -450,6 +450,42 @@ class TestProtocolTracker:
         assert updated is not None
         assert "abc1234" in updated["unregistered_commits"]
 
+    def test_detects_git_commit_cc2x_payload(self, tmp_path, mock_daemon):
+        """CC 2.x Bash payload registers commits (#75).
+
+        On Claude Code 2.x the Bash tool_response carries stdout under
+        ``stdout`` and has no ``exit_code`` (PostToolUse fires only on
+        success). The old ``.output`` / ``.exit_code == 0`` read saw an empty
+        string and a ``-1`` sentinel, so the git-commit branch never fired and
+        commits went unregistered. The shape-tolerant read fixes it.
+        """
+        from datetime import datetime, timezone  # noqa: UP017
+
+        from _protocol_cache import empty_cache, read_cache, write_cache
+        cache = empty_cache()
+        cache["state"] = "fix_loop"
+        cache["last_sahjhan_cmd"] = datetime.now(timezone.utc).isoformat()  # noqa: UP017
+        write_cache(str(tmp_path), cache)
+
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "git commit -m 'fix: stuff'"},
+            "tool_response": {
+                "stdout": "[dev abc1234] fix: stuff",
+                "stderr": "",
+                "interrupted": False,
+                "isImage": False,
+                "noOutputExpected": False,
+            },
+            "cwd": str(tmp_path),
+        }
+        code, _output, _ = run_enforcement_hook("protocol_tracker.py", event)
+        assert code == 0
+
+        updated = read_cache(str(tmp_path))
+        assert updated is not None
+        assert "abc1234" in updated["unregistered_commits"]
+
     def test_increments_stall_counter(self, tmp_path, mock_daemon):
         """Non-git, non-sahjhan, non-TDD commands increment stall."""
         from datetime import datetime, timezone  # noqa: UP017

--- a/tests/test_quiz_capture.py
+++ b/tests/test_quiz_capture.py
@@ -56,10 +56,23 @@ _QUESTION = {
 
 
 def _bash_event(output: str, cwd: str) -> dict:
+    """Build a realistic Claude Code 2.x Bash PostToolUse event.
+
+    CC 2.x delivers Bash stdout under ``tool_response.stdout`` — there is no
+    ``output`` key and no ``exit_code`` (verified live on 2.1.x). Tests use the
+    real shape so a regression to reading ``.output`` (the #75 bug) fails here
+    instead of passing against a synthetic payload the runtime never sends.
+    """
     return {
         "tool_name": "Bash",
         "tool_input": {"command": "python3 quiz_stage.py ..."},
-        "tool_response": {"exit_code": 0, "output": output},
+        "tool_response": {
+            "stdout": output,
+            "stderr": "",
+            "interrupted": False,
+            "isImage": False,
+            "noOutputExpected": False,
+        },
         "cwd": cwd,
     }
 
@@ -70,6 +83,26 @@ def test_captures_question_into_vault(tmp_path, mock_daemon):
     code, _ = _run(_bash_event(marker, str(tmp_path)), str(tmp_path))
     assert code == 0
     assert "quiz-bank" in mock_daemon.vault
+    stored = json.loads(mock_daemon.vault["quiz-bank"])
+    assert stored == [_QUESTION]
+
+
+def test_captures_from_legacy_output_field(tmp_path, mock_daemon):
+    """Pre-2.x Claude Code delivered stdout under ``tool_response.output``.
+
+    The shape-tolerant read must still capture from that legacy field so the
+    courier keeps working across Claude Code versions (#75 fallback path).
+    """
+    _target_source(tmp_path)
+    marker = "QUIZ-QUESTION: " + json.dumps(_QUESTION, separators=(",", ":"))
+    legacy_event = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "python3 quiz_stage.py ..."},
+        "tool_response": {"exit_code": 0, "output": marker},
+        "cwd": str(tmp_path),
+    }
+    code, _ = _run(legacy_event, str(tmp_path))
+    assert code == 0
     stored = json.loads(mock_daemon.vault["quiz-bank"])
     assert stored == [_QUESTION]
 


### PR DESCRIPTION
## v0.138.1 — patch release

Fixes a hard blocker introduced by a Claude Code payload-shape change: the lens-quiz vault never populated, making `recon_complete` unsatisfiable and convergence unreachable on every run under Claude Code 2.x.

### Fixed
- **enforcement:** read Bash stdout from `tool_response.stdout` (#75)

### Root cause

Claude Code 2.x delivers Bash `PostToolUse` output under `tool_response.stdout` and **omits `exit_code` entirely**. The hooks read `tool_response.output` / `.exit_code`, which no longer exist:

- `quiz_capture` saw `""`, so every staged `QUIZ-QUESTION:` marker was dropped, `quiz_bank_generated` was never recorded, and `recon_complete` was permanently blocked.
- `protocol_tracker`'s git-commit registration was silently dead too — its `exit_code == 0` guard could never be true.

Payload shape verified live against Claude Code 2.1.x:

```json
{"stdout":"…","stderr":"","interrupted":false,"isImage":false,"noOutputExpected":false}
```

A non-zero-exit Bash command does not fire `PostToolUse` at all.

### Fix

Shape-tolerant `bash_output()` / `bash_exit_code()` helpers in `hooks/_common.py` (re-exported via `enforcement/hooks/_common.py`), so both hooks read `stdout` first and fall back to the pre-2.x `output` key. A missing `exit_code` defaults to `0`, not a sentinel — 2.x fires `PostToolUse` only after a tool call succeeds, so absence means success.

### Why this shipped green

Every prior test built the synthetic `{"exit_code", "output"}` payload the runtime never sends. Tests now construct the real 2.x event shape, so these would have caught it. Also regenerated `trusted-callers.toml` — editing a daemon-calling hook changes its SHA-256, and a stale manifest makes the daemon reject the caller, silently failing every gate open.

### Verification

- `scripts/pre-release-check.sh`: **ALL PASSED**
- Full suite exit 0, coverage **91.24%** (gate 80%)
- ruff / mypy clean (48 files); contract gate 38/38; hook smoke 9/9
- CI green on dev @ `abf3cb3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)