### PR TITLE
chore: release v0.138.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.138.1",
+  "version": "0.138.2",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.138.2] - 2026-07-22
+
+_Changes since v0.138.1_
+
+### Fixed
+- **enforcement:** derive pattern-overdue counter from the ledger (#77)
+
 ## [0.138.1] - 2026-07-21
 
 _Changes since v0.138.0_

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/jbrjake/holtz/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/jbrjake/holtz/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)
-![1761 tests](https://img.shields.io/badge/tests-1761_total-brightgreen.svg)
+![1771 tests](https://img.shields.io/badge/tests-1771_total-brightgreen.svg)
 ![91% coverage](https://img.shields.io/badge/coverage-91%25-brightgreen.svg)
 
 **Adversarial TDD audit loop for Claude Code.** Dual auditors find bugs, write failing tests, fix them, and repeat until two consecutive passes find nothing new.

--- a/docs/superpowers/plans/2026-07-22-issue-77-commit-gate-counter-derive.md
+++ b/docs/superpowers/plans/2026-07-22-issue-77-commit-gate-counter-derive.md
@@ -1,0 +1,85 @@
+# Issue #77: commit_gate pattern-overdue counter diverges from ledger → deadlock
+
+**Goal:** Kill the spurious `git commit` deadlock where the "Pattern analysis
+overdue" hard block fires on a cached counter that has drifted from the ledger,
+directing the auditor to run `transition pattern_check` — a transition whose own
+gate is *blocked* because the ledger shows `< 3` findings resolved. The escape
+is unsatisfiable.
+
+**Root cause:** `enforcement/hooks/protocol_tracker.py::_apply_sahjhan_cmd`
+maintained `fixes_since_pattern` as a **hand-mirrored** counter, incremented on
+the mere *presence* of the token `fix_commit` and reset on `pattern_check` /
+`pattern_done` — anywhere in the command text. Read-only diagnostics
+(`sahjhan gate check fix_commit`, `sahjhan query "... 'fix_commit' ..."`,
+`sahjhan gate check pattern_check`) contain those tokens, so they silently moved
+a gate-controlling counter. Meanwhile the authoritative `pattern_check`
+transition gate counts real ledger `finding_resolved` events. Two independent
+counters → drift → deadlock.
+
+## Decision: derive, don't mirror (issue's preferred fix #1)
+
+Compute `fixes_since_pattern` **from the ledger** — the exact query the
+`pattern_check` gate uses (`enforcement/transitions.toml`):
+
+```sql
+SELECT count(*) FROM events
+WHERE type='finding_resolved'
+  AND seq > COALESCE((SELECT MAX(seq) FROM events WHERE type='pattern_analysis_complete'), 0)
+```
+
+Then the commit-gate block condition (`counter >= 3`) and the `pattern_check`
+gate readiness (`finding_resolved >= 3`) are the **same fact**, so they can never
+disagree: whenever the commit gate blocks, the escape it prints is satisfiable.
+
+## No sahjhan change required — and shouldn't be
+
+sahjhan already ships a generic `query` primitive (`sahjhan --config-dir <dir>
+query "<sql>" --format json`, resolves the active-ledger marker — the same ledger
+the gates evaluate). The SQL above is **holtz domain logic** (`finding_resolved`,
+`pattern_analysis_complete` are holtz event types) and stays entirely in holtz.
+Pushing it into the engine would pollute sahjhan's generic state machine with
+holtz business logic — exactly what the project forbids. Verified empirically
+against a real v0.19.0 ledger: 2 `finding_resolved` → `n=2`; after a
+`pattern_analysis_complete` baseline + 1 more → `n=1`.
+
+## Changes
+
+1. **`enforcement/hooks/protocol_tracker.py`**
+   - `_refresh_from_sahjhan`: after the status refresh, when state is
+     `fix_loop`/`pattern_analysis`, run the ledger count query and set
+     `cache["fixes_since_pattern"]` from it. Query failure → leave the previous
+     value (safe: under-count only delays the nudge, never deadlocks).
+   - `_apply_sahjhan_cmd`: delete the token-mirror increment/reset. Keep the
+     pending-commit clear, but scope it to the **mutating** `transition
+     fix_commit` verb (`_runs_transition`), so a diagnostic that merely mentions
+     `fix_commit` can't silently clear a real pending commit either.
+
+2. **`enforcement/hooks/commit_gate.py`** — unchanged. It reads
+   `cache["fixes_since_pattern"]`, now ledger-derived. Kept subprocess-free so it
+   stays fast on every Bash call.
+
+3. **Tests**
+   - `tests/test_protocol_enforcement.py`: the mock full-cycle test no longer
+     asserts the counter increments on token match (mirror removed); it asserts
+     the pending-commit clear still works and the counter is *not* moved without
+     a real ledger. New mock tests prove diagnostics don't move the counter.
+   - `tests/test_e2e_audit_flow.py`: new `real_daemon` test — append N
+     `finding_resolved`, run protocol_tracker, assert the derived counter == N,
+     assert the commit gate blocks at 3 **and** the `pattern_check` gate is
+     simultaneously ready (escape satisfiable). This is the regression guard for
+     the deadlock.
+
+4. **`enforcement/trusted-callers.toml`** — regenerated (protocol_tracker.py hash
+   changed; a stale manifest silently disables enforcement).
+
+## Failure modes addressed (all four from the issue)
+
+1. Over-count → spurious block: gone. Diagnostics trigger a refresh that
+   re-derives from the ledger; block condition ≡ pattern_check readiness.
+2. Under-count → silent skip: gone. Diagnostics no longer zero the counter.
+3. Cross-`/clear` staleness: the counter re-derives on the first sahjhan command
+   of the new window (`resume`), and the `iteration_boundary` gate already forces
+   a pattern round before `/clear`, moving the baseline.
+4. Shell-var indirection: the counter no longer depends on token-matching in
+   `_apply_sahjhan_cmd`; any later recognized sahjhan command re-derives it, so
+   indirection can't permanently corrupt it.

--- a/enforcement/hooks/protocol_tracker.py
+++ b/enforcement/hooks/protocol_tracker.py
@@ -7,6 +7,7 @@ updates the enforcement cache file. Never blocks. Pure bookkeeping.
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import re
 import subprocess
@@ -75,6 +76,62 @@ def _parse_commit_hash(output: str) -> str:
     return m.group(1) if m else "unknown"
 
 
+def _runs_transition(cmd: str, command: str) -> bool:
+    """True iff cmd invokes ``sahjhan ... transition <command>`` (verb-adjacent).
+
+    Distinguishes the *mutating* transition from read-only diagnostics that
+    merely mention the command name as a bare token — ``sahjhan gate check
+    fix_commit``, ``sahjhan query "... 'fix_commit' ..."``, ``sahjhan status``.
+    Only the actual transition should move cache bookkeeping. #77.
+    """
+    tokens = cmd.split()
+    return any(
+        tok == "transition" and tokens[i + 1] == command
+        for i, tok in enumerate(tokens[:-1])
+    )
+
+
+# #77: the authoritative backlog for "pattern analysis overdue" is the ledger,
+# NOT a hand-mirrored counter. This is the SAME query the `pattern_check`
+# transition gate uses (enforcement/transitions.toml) — count finding_resolved
+# events since the last pattern_analysis_complete. Deriving fixes_since_pattern
+# from it means the commit gate's block condition (>= 3) and the pattern_check
+# gate's readiness (>= 3) are one fact and can never disagree, so the block's
+# printed escape ("run transition pattern_check") is always satisfiable.
+_FIXES_SINCE_PATTERN_SQL = (
+    "SELECT count(*) AS n FROM events "
+    "WHERE type='finding_resolved' "
+    "AND seq > COALESCE((SELECT MAX(seq) FROM events "
+    "WHERE type='pattern_analysis_complete'), 0)"
+)
+
+
+def _query_fixes_since_pattern(binary: str, config_dir: str, cwd: str) -> int | None:
+    """Ledger-derived count of finding_resolved since the last pattern analysis.
+
+    Runs sahjhan's generic `query` primitive against the active ledger (the same
+    ledger the gates evaluate). Returns None on any failure — binary/daemon
+    unavailable, timeout, non-zero exit, or malformed output — so the caller
+    preserves the last known counter instead of resetting it. An under-count
+    only delays the pattern nudge; it never deadlocks a commit. #77.
+    """
+    try:
+        result = subprocess.run(
+            [binary, "--config-dir", config_dir, "query",
+             _FIXES_SINCE_PATTERN_SQL, "--format", "json"],
+            capture_output=True, text=True, timeout=5, cwd=cwd,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        rows = json.loads(result.stdout)
+        return int(rows[0]["n"])
+    except (json.JSONDecodeError, KeyError, IndexError, ValueError, TypeError):
+        return None
+
+
 def _refresh_from_sahjhan(cwd: str, cache: dict) -> dict:
     """Query sahjhan status (text) and update cache fields.
 
@@ -82,6 +139,10 @@ def _refresh_from_sahjhan(cwd: str, cache: dict) -> dict:
     which can run the project's test suite — guaranteed to blow the 5s
     timeout below and silently keep stale bookkeeping (#57). The refresh
     only needs state/sets, never gate readiness.
+
+    fixes_since_pattern is re-derived from the ledger here (only while it
+    matters — fix_loop/pattern_analysis), never mirrored by token-matching the
+    command text. #77.
     """
     binary = ensure_sahjhan()
     if binary is None:
@@ -108,6 +169,14 @@ def _refresh_from_sahjhan(cwd: str, cache: dict) -> dict:
     cache["perspectives_total"] = perspective.get("total", 0) or cache.get("perspectives_total", 13)
     cache["stall"] = 0
     cache["active"] = cache.get("state", "") not in ("", "idle", "finalized")
+
+    # Derive the pattern-analysis backlog from the ledger, but only in the
+    # states where it's consumed — avoids a subprocess on every recon/audit
+    # sahjhan command. Query failure keeps the previous value.
+    if cache.get("state") in ("fix_loop", "pattern_analysis"):
+        fixes = _query_fixes_since_pattern(binary, config_dir, cwd)
+        if fixes is not None:
+            cache["fixes_since_pattern"] = fixes
     return cache
 
 
@@ -146,13 +215,14 @@ def _apply_sahjhan_cmd(cwd: str, cache: dict | None, cmd: str) -> dict:
     # Stop daemon after finalization (teardown safety net)
     if cache.get("state") == "finalized":
         _stop_daemon(cwd)
-    # BH-017: match subcommand tokens, not substrings of full command
-    tokens = cmd.split()
-    if "fix_commit" in tokens:
+    # #77: fixes_since_pattern is DERIVED from the ledger in _refresh_from_sahjhan
+    # (the same query the pattern_check gate uses), not mirrored by token-matching
+    # the command text — a read-only diagnostic that only mentions `fix_commit`/
+    # `pattern_check` no longer moves it. The pending-commit registration is still
+    # cache-tracked, but it clears solely on the mutating `transition fix_commit`
+    # verb, so a diagnostic can't silently clear a real pending commit either.
+    if _runs_transition(cmd, "fix_commit"):
         cache["unregistered_commits"] = []
-        cache["fixes_since_pattern"] = cache.get("fixes_since_pattern", 0) + 1
-    if "pattern_check" in tokens or "pattern_done" in tokens:
-        cache["fixes_since_pattern"] = 0
     with contextlib.suppress(RuntimeError):
         write_cache(cwd, cache)
     return cache

--- a/enforcement/trusted-callers.toml
+++ b/enforcement/trusted-callers.toml
@@ -19,6 +19,6 @@
 "hooks/post_tool_hook.py" = "sha256:63e513159f24f79c3d23bac2d30a77e315b9905c578472dde0329e52c1918947"
 "hooks/commit_gate.py" = "sha256:e1b26fae9dace0e9556fdad292eb34e102b2a3f03d705beaed4e28145458b840"
 "hooks/bash_guard.py" = "sha256:a534dca9da6509d573c25965dda2c29d7cd2196cd8486a1837d0965f6d5e5a09"
-"hooks/protocol_tracker.py" = "sha256:2140adb5c0e90fd9540293754630541cdddaf900de065afe22fd622abef519fa"
+"hooks/protocol_tracker.py" = "sha256:f7df69d32e5defade6c862bea0e3a8f30254576131e10d73296f93c3dfbb3314"
 "hooks/quiz_capture.py" = "sha256:3d1697849e6a9a313f29bb9745c1181ba69a31258eec27f4bb84b65afe0484aa"
 "hooks/subagent_findings_check.py" = "sha256:f97d12f1d431dad0f9a88ea25c24e923acb3d0a6f4722c0bfb4d047fb161d921"

--- a/tests/test_e2e_audit_flow.py
+++ b/tests/test_e2e_audit_flow.py
@@ -143,6 +143,30 @@ def _freshen_enforcement_cache(real_daemon) -> None:
     _invoke_hook("protocol_tracker.py", event, real_daemon)
 
 
+def _record_finding_resolved(real_daemon, item_id: str, step: str = "10") -> None:
+    """Append a real finding_resolved event to the active ledger."""
+    _run_sahjhan(
+        real_daemon, "event", "finding_resolved",
+        "--field", "project=holtz",
+        "--field", "run=1",
+        "--field", "auditor=holtz",
+        "--field", "phase=fix_loop",
+        "--field", f"step={step}",
+        "--field", f"id={item_id}",
+        "--field", "commit_hash=abc1234",
+    )
+
+
+def _run_tracker(real_daemon, command: str) -> None:
+    """Run protocol_tracker (PostToolUse) against an arbitrary Bash command."""
+    _invoke_hook("protocol_tracker.py", {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "tool_response": {"exit_code": 0, "output": ""},
+        "cwd": real_daemon["project_root"],
+    }, real_daemon)
+
+
 class TestTddGateBlocksWriteInFixLoop:
     """The flagship enforcement: Write/Edit in fix_loop without a failing test
     must be blocked with a message telling the model to record
@@ -870,4 +894,107 @@ class TestFixCommitAutoEmitsFindingResolved:
         open_count = int(json.loads(result.stdout)[0]["open"])
         assert open_count == 0, (
             f"after fix_commit auto-emit, no findings should remain open; got {open_count}"
+        )
+
+
+class TestCommitGatePatternCounterDerivation:
+    """#77: the commit gate's 'pattern analysis overdue' hard block must be
+    driven by the LEDGER (finding_resolved since the last pattern analysis) —
+    the same fact the pattern_check transition gate reads — not by a cache
+    counter that token-matching kept in a separate, drifting mirror.
+
+    The regression these guard against is a *deadlock*: the commit gate blocks a
+    legitimate fix commit and tells the auditor to run `transition
+    pattern_check`, while that transition's own gate is simultaneously blocked
+    because the ledger shows < 3 findings resolved. The printed escape is
+    unsatisfiable. Deriving the counter from the ledger makes block-condition ≡
+    escape-readiness, so that can never happen.
+
+    These assert observable *enforcement behavior* through the subprocess
+    commit_gate hook (a trusted daemon caller) rather than reading the
+    enforcement cache in-process — the pytest process is not a trusted caller,
+    so a direct enforcement_read is refused by design.
+    """
+
+    def _commit_decision(self, real_daemon, msg: str) -> dict:
+        return _invoke_hook("commit_gate.py", {
+            "tool_input": {"command": f"git commit -m {msg!r}"},
+            "cwd": real_daemon["project_root"],
+        }, real_daemon).get("hookSpecificOutput", {})
+
+    def test_commit_gate_block_boundary_tracks_ledger(self, real_daemon):
+        """The block boundary is the ledger count: a commit is allowed at 2
+        findings resolved and blocked at 3 — proving the counter that drives the
+        gate is derived from finding_resolved events, not a token mirror."""
+        _fast_forward_to_fix_loop(real_daemon)
+        _record_finding_resolved(real_daemon, "BH-001")
+        _record_finding_resolved(real_daemon, "BH-002")
+        _freshen_enforcement_cache(real_daemon)  # protocol_tracker derives -> 2
+
+        allowed = self._commit_decision(real_daemon, "fix: BH-002")
+        assert allowed.get("permissionDecision") == "allow", (
+            f"2 findings resolved (< 3) must not be pattern-blocked; got {allowed}"
+        )
+
+        _record_finding_resolved(real_daemon, "BH-003")
+        _freshen_enforcement_cache(real_daemon)  # derives -> 3
+
+        blocked = self._commit_decision(real_daemon, "fix: BH-003")
+        assert blocked.get("permissionDecision") == "deny", (
+            f"3 findings resolved must trigger the pattern-overdue block; got {blocked}"
+        )
+        assert "pattern" in blocked.get("permissionDecisionReason", "").lower()
+
+    def test_diagnostics_do_not_move_the_counter(self, real_daemon):
+        """Failure modes 1 & 2: read-only diagnostics that merely MENTION
+        `fix_commit` / `pattern_check` as tokens must neither inflate the counter
+        (spurious block) nor reset it (silent skip)."""
+        _fast_forward_to_fix_loop(real_daemon)
+        _record_finding_resolved(real_daemon, "BH-001")
+        _record_finding_resolved(real_daemon, "BH-002")
+
+        # Mode 1: the old mirror would inflate on each `fix_commit` token. The
+        # ledger truth is 2, so the commit stays allowed after any number of them.
+        _run_tracker(real_daemon, "sahjhan gate check fix_commit")
+        _run_tracker(real_daemon, "sahjhan gate check fix_commit")
+        _run_tracker(real_daemon, "sahjhan gate check fix_commit")
+        allowed = self._commit_decision(real_daemon, "fix: BH-002")
+        assert allowed.get("permissionDecision") == "allow", (
+            f"diagnostics mentioning fix_commit must not inflate the counter into "
+            f"a spurious block; got {allowed}"
+        )
+
+        # Mode 2: a diagnostic mentioning `pattern_check` must NOT zero the
+        # counter. Bring the ledger to 3, then run such a diagnostic to freshen:
+        # the derived counter is 3, so the commit is (correctly) blocked.
+        _record_finding_resolved(real_daemon, "BH-003")
+        _run_tracker(real_daemon, "sahjhan gate check pattern_check")
+        blocked = self._commit_decision(real_daemon, "fix: BH-003")
+        assert blocked.get("permissionDecision") == "deny", (
+            f"a diagnostic mentioning pattern_check must not silently reset the "
+            f"ledger-derived count of 3; got {blocked}"
+        )
+
+    def test_hard_block_escape_is_satisfiable(self, real_daemon):
+        """The core of #77: when the commit gate hard-blocks on 'pattern
+        overdue', the escape it prints (`transition pattern_check`) must be
+        runnable at that same instant — its gate ready. No deadlock."""
+        _fast_forward_to_fix_loop(real_daemon)
+        _record_finding_resolved(real_daemon, "BH-001")
+        _record_finding_resolved(real_daemon, "BH-002")
+        _record_finding_resolved(real_daemon, "BH-003")
+        _freshen_enforcement_cache(real_daemon)
+
+        blocked = self._commit_decision(real_daemon, "fix: BH-003")
+        assert blocked.get("permissionDecision") == "deny"
+        assert "pattern" in blocked.get("permissionDecisionReason", "").lower()
+
+        # The printed escape is satisfiable: pattern_check transition succeeds NOW
+        # (exit 0). If this were the old drifting mirror, the counter could hit 3
+        # while the ledger held < 3, and this transition would exit 1 — deadlock.
+        result = _run_sahjhan(real_daemon, "transition", "pattern_check", check=False)
+        assert result.returncode == 0, (
+            "commit gate directed the auditor to `transition pattern_check`, but "
+            "its own gate rejected it — the exact #77 deadlock.\n"
+            f"exit: {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
         )

--- a/tests/test_protocol_enforcement.py
+++ b/tests/test_protocol_enforcement.py
@@ -412,6 +412,47 @@ class TestParseStatusText:
         assert result["run_number"] == "0"
 
 
+class TestRunsTransition:
+    """#77: _runs_transition distinguishes the mutating `transition <cmd>` verb
+    from read-only diagnostics that only mention the command name as a token.
+    This is what stops a diagnostic from silently moving cache bookkeeping."""
+
+    def test_bare_transition_matches(self):
+        from protocol_tracker import _runs_transition
+        assert _runs_transition("sahjhan transition fix_commit BH-001", "fix_commit")
+
+    def test_transition_with_config_dir_matches(self):
+        from protocol_tracker import _runs_transition
+        assert _runs_transition(
+            "sahjhan --config-dir /x/y transition fix_commit BH-001", "fix_commit"
+        )
+
+    def test_pattern_check_transition_matches(self):
+        from protocol_tracker import _runs_transition
+        assert _runs_transition("sahjhan transition pattern_check", "pattern_check")
+
+    def test_gate_check_diagnostic_does_not_match(self):
+        from protocol_tracker import _runs_transition
+        assert not _runs_transition("sahjhan gate check fix_commit", "fix_commit")
+        assert not _runs_transition("sahjhan gate check pattern_check", "pattern_check")
+
+    def test_query_mentioning_token_does_not_match(self):
+        from protocol_tracker import _runs_transition
+        assert not _runs_transition(
+            "sahjhan query \"SELECT * FROM events WHERE command='fix_commit'\"",
+            "fix_commit",
+        )
+
+    def test_flag_value_does_not_match(self):
+        from protocol_tracker import _runs_transition
+        assert not _runs_transition("sahjhan status --ledger fix_commit-test", "fix_commit")
+
+    def test_trailing_transition_token_is_safe(self):
+        """`transition` as the final token must not index past the end."""
+        from protocol_tracker import _runs_transition
+        assert not _runs_transition("sahjhan transition", "fix_commit")
+
+
 class TestProtocolTracker:
     """Tests for protocol_tracker.py PostToolUse hook."""
 
@@ -967,7 +1008,11 @@ class TestEnforcementIntegration:
         # 5. Verify unregistered commits cleared
         c = read_cache(str(tmp_path))
         assert c["unregistered_commits"] == []
-        assert c["fixes_since_pattern"] == 1
+        # #77: fixes_since_pattern is derived from the ledger, no longer a
+        # token-incremented mirror. With no real ledger behind the mock daemon
+        # the transition can't bump it — the derived-count path is covered by the
+        # real_daemon test in tests/test_e2e_audit_flow.py.
+        assert c["fixes_since_pattern"] == 0
 
         # 6. Gate allows next commit
         _, out, _ = run_enforcement_hook("commit_gate.py", {


### PR DESCRIPTION
## Release v0.138.2

Patch release fixing a spurious `git commit` deadlock in the enforcement chain.

### Fixed
- **enforcement:** derive the pattern-overdue counter from the ledger (#77)

### What was broken (#77)
The commit gate's **"Pattern analysis overdue"** hard block was driven by
`fixes_since_pattern`, a daemon-cached counter that `protocol_tracker`
maintained by token-matching command text (+1 on any command containing the
bare token `fix_commit`, reset on `pattern_check`/`pattern_done`). Read-only
diagnostics carry those tokens too (`sahjhan gate check fix_commit`,
`sahjhan query "... 'fix_commit' ..."`), so they silently moved a
gate-controlling counter, drifting it off the ledger's authoritative
`finding_resolved` count.

The drift produced a **deadlock**: the commit gate blocked a legitimate fix
commit and told the auditor to run `transition pattern_check`, but that
transition's own gate counts `finding_resolved` and was itself blocked at
`< 3` — the printed escape was unsatisfiable.

### The fix
`fixes_since_pattern` is now **derived from the ledger** in
`_refresh_from_sahjhan`, running the *same* query the `pattern_check` gate uses.
The commit-gate block condition and the transition-gate readiness are one fact
and can never disagree, so the block is always satisfiable. The token mirror is
removed; the pending-commit clear is scoped to the mutating
`transition fix_commit` verb.

**No sahjhan change:** the engine already exposes a generic `query` primitive;
the holtz-domain SQL stays in holtz, keeping the engine's state machine generic.

### Tests
- `real_daemon` regression guards (test_e2e_audit_flow.py): the block boundary
  tracks the ledger, diagnostics don't move the counter, and the hard block's
  escape is satisfiable (`transition pattern_check` exits 0). Verified these fail
  against the old token-mirror code.
- Unit tests for `_runs_transition`.

### Gates (observed)
- Full suite: `pytest ... --cov-fail-under=80` → exit 0, coverage 90.56%.
- `scripts/pre-release-check.sh` → ALL PASSED (ruff, mypy, contract gate, schema
  freshness, full suite, hook smoke test 9/9, version bump 0.138.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)