### PR TITLE
chore: release v0.138.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holtz",
   "description": "Systematic TDD-driven bug hunting with dual auditors. Holtz is depth-first and methodical; Justine is breadth-first and aggressive. Together they find what neither sees alone. Keeps coming back until the codebase converges. Will steal your joy.",
-  "version": "0.138.2",
+  "version": "0.138.3",
   "author": {
     "name": "Jon Rubin",
     "email": "jb.rubin@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _Changes since v0.138.2_
 ### Fixed
 - **enforcement:** record context_reset from a real reset, not any prompt (#79)
 
+### Infrastructure
+- cover the SessionStart hook in the release smoke test
+
 ## [0.138.2] - 2026-07-22
 
 _Changes since v0.138.1_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.138.3] - 2026-07-25
+
+_Changes since v0.138.2_
+
+### Fixed
+- **enforcement:** record context_reset from a real reset, not any prompt (#79)
+
 ## [0.138.2] - 2026-07-22
 
 _Changes since v0.138.1_

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/jbrjake/holtz/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/jbrjake/holtz/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Python 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)
-![1771 tests](https://img.shields.io/badge/tests-1771_total-brightgreen.svg)
+![1799 tests](https://img.shields.io/badge/tests-1799_total-brightgreen.svg)
 ![91% coverage](https://img.shields.io/badge/coverage-91%25-brightgreen.svg)
 
 **Adversarial TDD audit loop for Claude Code.** Dual auditors find bugs, write failing tests, fix them, and repeat until two consecutive passes find nothing new.
@@ -207,7 +207,7 @@ Advisory language asks. Hooks enforce.
 
 ## What's inside
 
-1 skill, 3 agents, 24 reference docs, 1 example, 8 Python scripts, 16 seed patterns, 12 enforcement hooks, 2 backstories you probably shouldn't read late at night, and two people who will find what's wrong with your code whether you want them to or not.
+1 skill, 3 agents, 24 reference docs, 1 example, 8 Python scripts, 16 seed patterns, 13 enforcement hooks, 2 backstories you probably shouldn't read late at night, and two people who will find what's wrong with your code whether you want them to or not.
 
 For the full capability inventory, file layout, enforcement architecture, and what's still on the workbench, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,8 @@ Python hooks in two locations:
 | `subagent_findings_check.py` | SubagentStop | Validates subagent output files exist |
 | `lens_quiz.py` | SubagentStop | Three-phase lens validation (evidence → quiz → score) |
 | `stop_hook.py` | Stop | Blocks stop in non-terminal states |
-| `primer.py` | UserPromptSubmit | Injects resume context on session restart |
+| `primer.py` | UserPromptSubmit | Injects resume context; probes daemon liveness and caller auth |
+| `session_start.py` | SessionStart | Records `context_reset` when `source` is `clear`, `compact`, or `startup` — the only writer of the event that gates `awaiting_clear -> fix_loop` (#79) |
 
 **Enforcement hooks** (`enforcement/hooks/`): The Python modules that implement the logic above.
 

--- a/docs/superpowers/plans/2026-07-14-open-issues-worklog.md
+++ b/docs/superpowers/plans/2026-07-14-open-issues-worklog.md
@@ -1,0 +1,292 @@
+# Open-issues worklog — 2026-07-14 (resumable across /clear)
+
+Working through open GitHub issues on `jbrjake/holtz` in priority + dependency
+order. Authorized scope this session:
+- Make changes in **sahjhan** directly, commit, cut GitHub releases as needed,
+  and re-integrate into holtz autonomously.
+- **Keep sahjhan generic** — no domain-specific (holtz) business logic baked into
+  the engine. Request generic capabilities; file `jbrjake/sahjhan` issues as
+  needed.
+- Commit + document as we go; close issues with citations as soon as possible.
+
+Repos: holtz `/Users/jonr/Documents/code/holtz` (branch `dev`), sahjhan
+`/Users/jonr/Documents/code/sahjhan`. Don't run the plugin against itself
+(install-hooks.sh defaults to dev mode — enforcement hooks NOT wired into this
+repo's session). Gate/pre-commit hooks (ruff+mypy+fast pytest+contract) ARE
+installed; do not `--no-verify` silently. `python3` not bare `python`.
+
+## Priority ranking (from maintainer comments)
+P0 convergence-blocking: **#67**, **#65**, **#63** (+ #70.5, same root cause).
+P1: **#70** (grab-bag), **#71** (heredoc bypass), **#69** (stop-hook pause).
+P2/P3 feature requests: #6 #8 #9 #10 #11 #12 #13 #26 (not started; lower prio).
+
+## BRANCH STATE (v0.137.2 release PR #72) — NOT actually diverged
+CORRECTION: an earlier note here claimed main/dev "diverged" by 817 commits.
+That was a SHALLOW-CLONE artifact — the local clone had `.git/shallow`, so
+`git log main --not dev` counted phantom commits across the truncated boundary.
+After `git fetch --unshallow`, the real picture is a totally normal dev→main
+flow: main-not-dev = 20 commits, ALL `chore: release …` + `Merge pull request
+#NN from jbrjake/dev` housekeeping from prior release PRs; dev-not-main = 12,
+exactly the work since v0.136.0. Merging origin/main into dev was a clean
+ANCESTRY-ONLY merge (`git diff HEAD` empty — zero content change) that brought
+dev up-to-date with main's release-merge commits. Lesson: on a shallow clone,
+`git fetch --unshallow` BEFORE reasoning about branch topology.
+main requires strict (up-to-date) status checks; enforce_admins=false. The
+correct fix for BEHIND is `gh pr update-branch` / merge origin/main into dev
+(done), NOT admin-bypass or force. Merge PR #72 via `gh pr merge --merge`.
+
+## ✅ RELEASE v0.137.2 SHIPPED TO main (2026-07-15)
+PR #72 merged (dev→main); Release Action succeeded; tag v0.137.2 + GitHub
+Release published (not draft); main HEAD 9578af6 = plugin.json v0.137.2. All
+P0/P1 fixes are now on main. dev is now "behind" main by the new `chore:
+release v0.137.2` housekeeping commit — normal, handled at the next release.
+
+## ✅ P0 + P1 COMPLETE (2026-07-15)
+All P0 (#67, #65, #63) and P1 (#69, #70, #71) issues resolved and CLOSED on
+GitHub with citations. holtz `dev` at v0.137.2 (HEAD 2f641ab), CI run
+29444276033 = success. sahjhan v0.17.0 released + pinned. sahjhan #31 (engine
+ledger_has_event_since fix) also closed. Remaining open issues are all P2/P3
+feature requests (#6 #8 #9 #10 #11 #12 #13 #26) — per user directive, STOP here.
+Course-correction this session: initially deferred the sahjhan
+`ledger_has_event_since` fix (filed #31) — user called that out as a wrong
+route-around; I fixed the engine bug properly in v0.17.0 instead (parse prefix,
+min_count, field filter), repairing the live `set complete perspective` gate.
+
+## STATUS
+
+### ✅ #67 — fix_commit lifetime 15-cap → per-iteration. DONE, closed.
+Commit `a51ef66` (v0.136.2, on dev, pushed). transitions.toml fix_commit
+breaker now `seq > COALESCE((SELECT MAX(seq) ... command='iteration_boundary'),0)`.
+Regression test `test_fix_commit_breaker_scoped_to_iteration_not_lifetime`.
+
+### ✅ #65 — pattern_check chicken-and-egg. DONE, closed.
+Same commit `a51ef66`. pattern_check gate rewritten from broken
+`ledger_has_event_since since=last_event_of_type:...` to COALESCE query
+`SELECT count(*) >= 3 FROM events WHERE type='finding_resolved' AND seq >
+COALESCE((SELECT MAX(seq) FROM events WHERE type='pattern_analysis_complete'),0)`.
+Empirically validated with `sahjhan query`. Regression test
+`test_pattern_check_bootstraps_from_zero`.
+
+### SESSION 2026-07-15 PROGRESS (this session)
+Holtz commits on dev: #70.1 (`db26689` v0.136.5), #71 (`d0d43f6`+`2528a41`
+v0.136.6), #69 (`f3ef138` v0.137.0). Full-suite coverage 91% (CI-green).
+Closed on GitHub: #71, #69 (with citations).
+sahjhan v0.17.0 CONTENTS (commits on main): `2e4ad29` (#70.4 cwd-ledger
+walk-up), `818d27c` (#70.7 event_count event-type filter), `0cf7b07` (bump),
+`c2ff48e` + `7a64273` (sahjhan #31 ledger_has_event_since: parse
+last_event_of_type: prefix, honor min_count, honor field `filter`, missing
+baseline=seq0). This repairs the live holtz `set complete perspective` gate
+(transitions.toml:203) which uses BOTH the prefix AND filter — previously both
+were silently ignored (route-around territory). ledger_has_event_since fix is
+NOT deferred — user (2026-07-15) called out the deferral as wrong; fixed in
+this release. sahjhan #31 to be closed as fixed once v0.17.0 ships.
+RELEASE INTEGRITY NOTE: v0.17.0 tag was re-pointed twice while builds were
+in flight. FINAL tag/HEAD = `7a64273`. Before pinning, ensure the published
+v0.17.0 release binaries are from 7a64273 (delete+re-cut once from stable HEAD
+if any ambiguity), then pin + verify via check_sahjhan_pin.py.
+
+### RE-PIN (do NOW that v0.17.0 is releasing) → closes #63 + #70
+Re-pin holtz 0.15.0 -> 0.17.0 in ONE step. Steps:
+1. `_resolve.SAHJHAN_VERSION` = "0.17.0".
+2. `_resolve.SAHJHAN_CHECKSUMS` = the 4 sha256 from the v0.17.0
+   checksums.sha256 (gh release download / raw URL).
+3. `scripts/vendor-sahjhan.sh 0.17.0` (re-vendors bin/, writes untracked
+   .sahjhan-version marker). Binaries are gitignored — only _resolve.py commits.
+4. `python3 scripts/check_sahjhan_pin.py` must PASS.
+5. `pytest tests/test_sahjhan_pin.py` (invariant tests, no version hardcode).
+Then close #63 (+#70.5) and #70 (all items done: 1✅ 2✅ 3✅ 4✅ 5✅ 6✅ 7✅).
+bin/.sahjhan-version is UNTRACKED (single source of truth = SAHJHAN_VERSION).
+`bin/` active; `.claude-plugin/bin/` stale untracked leftover (ignore).
+
+### 🔧 #63 (+ #70 item 5) — gate command env + surface stderr. HALF DONE.
+- sahjhan v0.16.0 (`10cf274`, tag v0.16.0, RELEASED): command_succeeds/
+  command_output now surface a bounded stderr (or stdout) tail on failure. Done.
+- holtz (`33e7317`, v0.136.3): pytest/ruff gates now `${HOLTZ_PYTEST:-...}` /
+  `${HOLTZ_LINT:-...}` (sh-expanded, overridable per target); docs in
+  phase-fix-loop.md. Done.
+- REMAINING to CLOSE #63/#70.5: re-pin holtz to the batched sahjhan release
+  (>=0.16.0) so the stderr feature ships. Do at the final re-pin. THEN close
+  #63 and #70 item 5.
+- #70 item 6 (--item-id doc drift): DONE in `33e7317` (positional BH-NNN).
+Root cause analysis done:
+- `src/gates/command.rs` `eval_command_succeeds`/`eval_command_output` run
+  `sh -c cmd` (NOT login shell) inheriting the CALLER's env. It **captures
+  stderr then discards it** (`_stderr`), reporting only exit status → the
+  30-min "missing pytest vs real failure" diagnosis. **Fix (generic, sahjhan):
+  include captured stderr (tail) in the failure `reason`.** This is the XS win
+  the maintainer flagged as do-immediately.
+- Env/PATH: gates evaluate wherever `sahjhan transition`/`gate` runs (CLI
+  process, not necessarily the daemon). Need to confirm daemon-vs-CLIeval path
+  (see `src/cli/transition.rs`, `src/state/machine.rs`, daemon socket ops) and
+  decide the generic fix (maintainer option 1: run gate commands with the
+  daemon's env). `ruff check .` 127 (#70.5) is the same root cause.
+- After sahjhan changes: bump `Cargo.toml`, add Rust tests, commit, tag/release
+  on GitHub, then in holtz bump `enforcement/hooks/_resolve.py SAHJHAN_VERSION`
+  (currently "0.15.0"; bundled bin `.claude-plugin/bin/.sahjhan-version`=0.13.0
+  — there's drift to reconcile) + re-vendor binary (`scripts/vendor-sahjhan.sh`)
+  + `tests/test_sahjhan_pin.py`.
+
+### ⏳ Also needs generic sahjhan fix (found this session, folds into #65 follow-up):
+`ledger_has_event_since` (src/gates/ledger.rs:101) does NOT parse the
+`last_event_of_type:<type>` prefix (treats whole string as a literal event type,
+falls back to last state_transition) and ignores `min_count`. Still used live by
+the `set complete perspective` gate (transitions.toml:186,
+`since=last_event_of_type:set_member_complete`) — that gate is silently
+mis-scoped. **Generic sahjhan fix:** parse `last_event_of_type:<type>`, honor
+`min_count`, treat missing baseline as run start (seq 0). File sahjhan issue +
+implement in the same batch as #63. (holtz #65 itself already closed via the
+query rewrite — this is the follow-up that repairs line 186.)
+
+### ⏳ #70 — papercuts grab-bag. PARTIALLY DONE. Triage:
+- item 6 ✅ DONE (`33e7317`): fix_commit positional BH-NNN doc fix.
+- item 2 ✅ DONE (`db2d2c9`): TDD pre-edit gate now exempts docs/** + out-of-repo
+  (pre_tool_hook.py `_tdd_gate_exempt`). Tests: TestPreToolHookTddPathScope.
+- item 5 ✅ effectively DONE (env-override `${HOLTZ_LINT:-ruff check .}` in
+  `33e7317` + sahjhan stderr). Closes with #63 at re-pin.
+- item 1 ✅ DONE (`db26689`, v0.136.5): stall block was in `_protocol_cache.py`
+  `compute_obligations` (stall>15 → blocks_all) + `commit_gate.py`, not the bash
+  guard. Added `contains_sahjhan_cmd` (any segment sahjhan) beside strict
+  `is_sahjhan_cmd`; commit_gate lets a wrapped sahjhan re-sync through the stall
+  block (never a git commit); protocol_tracker resets stall on wrapped re-sync via
+  shared `_apply_sahjhan_cmd`. Message clarified. Tests: TestChickenAndEggStallBlock.
+- item 7 ⏳ TODO (fold into sahjhan BATCH): "N events since last state transition"
+  noise. Monitors live in `enforcement/hooks.toml` (fix_loop_stall threshold 20,
+  audit_stall 30) + Edit-accumulation warn (threshold 8). Root cause: the trigger
+  `event_count_since_last_transition` counts ALL ledger events incl. auto-recorded
+  file_read/source_edit/file_search (reads dominate). Principled fix: add
+  event-type filtering to the sahjhan trigger (generic), then count only
+  `source_edit` in holtz. Depends on v0.17.0 + re-pin.
+- item 4 ⏳ TODO (sahjhan BATCH): cwd-relative ledger resolution — a `cd` into a
+  subdir breaks all sahjhan calls (`Cannot open ledger: No such file...`). Make
+  ledger resolution walk up to the project/git root. sahjhan Rust
+  (`open_targeted_ledger` / `resolve_data_dir` in src/cli/commands.rs) + maybe
+  holtz `_resolve.py`. Generic → goes in the batched v0.17.0.
+- item 3: already fixed (patterns-brief.md author-editable; not in MANAGED_DOCS,
+  which is only STATUS/PUNCHLIST/SUMMARY).
+- To CLOSE #70: finish items 1, 7, 4; then verify all and close.
+
+### ✅ #71 — heredoc/redirection bypass of TDD gate. DONE (`d0d43f6`+`2528a41`, v0.136.6).
+Managed-path half was already guarded (`_check_bash_write`). Remaining gap = TDD
+gate not applied to bash source writes. Added to `_sahjhan_bootstrap.py`:
+`_strip_heredoc_bodies` (drop inert data), quote-aware shlex target extraction
+(`_bash_write_targets`: `>`/`>>`/heredoc/`tee`/`sed -i`; cp/mv excluded), and
+`_bash_source_write_tdd_block` → routes in-repo source targets through
+`sahjhan hook eval --tool Write` (same gate as Edit/Write); docs/out-of-repo
+exempt; fails closed mid-audit. Tests: test_bash_source_write_gate.py
+(over/under-block matrix + e2e gate + fail-closed unit branches). Close #71 now.
+Historical (superseded) plan:
+Extend the redirection-parser in `enforcement/hooks/_sahjhan_bootstrap.py` bash
+guard to route ordinary-source writes (`cat >`, `>>`, `tee`, `sed -i`, `cp`,
+`mv`, `dd`, `python -c open(...,'w')`) through the same TDD + managed-path
+checks, WITHOUT over-blocking quoted heredoc *data* (the scanner currently
+greps command text incl. heredoc bodies → false positives on issue prose). Do
+#70 item 2 first. holtz-only. Test: `test_issue46_bypass_regression.py` is the
+sibling pattern.
+
+### ⏳ #69 — Stop hook no pause-for-human. NOT STARTED.
+Add a lightweight reversible pause the Stop hook accepts (distinct from
+terminal). states.toml + transitions.toml (a `paused`/`awaiting_human` state
+with resume) + `enforcement/hooks/stop_hook.py`. Auto-resume. holtz-mostly.
+
+### ✅ #73 — Lens quiz gate unsatisfiable (vault never populated). DONE (2026-07-17).
+Convergence-blocking on every target: nothing populated the daemon vault, so
+lens_quiz posed no quiz, quiz_posed/quiz_answered never written, `set complete
+perspective`/converge unsatisfiable. Rebuilt around the maintainer's design
+(temporal integrity, NOT answer-hiding — see [[issue-73-quiz-channel-design]]).
+
+sahjhan v0.19.0 (`60bd4aa`, main, RELEASED): generic **state-gated vault keys**
+— `vault.toml` `[[policy]] name writable/readable/deletable_in_states`; daemon
+derives current state from the active ledger and rejects out-of-state
+vault_store/read/delete. Sealed as the 8th config file. Backward compatible
+(no policy = unrestricted). Rust unit + real-daemon e2e tests.
+
+holtz `2551cbe` (v0.138.0, dev) + `9413b95` (test):
+- Recon Step 5: a generation subagent derives per-lens questions from the impact
+  graph, stages each via `skills/holtz/scripts/quiz_stage.py`; trusted PostToolUse
+  courier `quiz_capture.py` appends to the `quiz-bank` vault key (freshness-verified
+  → forces code-anchored questions). Vault-only (ledger is cat-readable).
+- `enforcement/vault.toml`: quiz-bank writable only in recon, readable only in
+  sweep states → channel closes at recon_complete. `recon_complete` gate now
+  requires `quiz_bank_generated` (can't leave recon bankless).
+- `enforcement/hooks/quiz_vault.py` (store/read/append/read_safe); lens_quiz reads
+  the vault + reads agent_transcript_path OR transcript_path (Defect B) + actionable
+  stale message (Defect C). Removed the old disk-source `quiz_bank_loader`.
+- Re-pinned sahjhan 0.18.0→0.19.0. New hook wired in hooks.json + manifest +
+  trusted-callers. Verified: sahjhan suite (35 bins) + vault-policy e2e; holtz fast
+  + slow (real-daemon) + contract; `sahjhan validate` on the config; full coverage
+  89.82%; dev CI run 29607998884 = success.
+NOT run: a full end-to-end audit (recon→sweep→converge) — component + integration
+verified, but the whole-run convergence claim rests on those, not an observed run.
+
+### ✅ #79 — awaiting_clear gate satisfied without a real /clear. DONE (2026-07-25).
+P1 enforcement integrity, opposite in direction to #73: a gate satisfied when it
+shouldn't be. `primer.py` recorded `context_reset` on **every**
+`UserPromptSubmit` — including automated background-task notifications — so the
+`awaiting_clear -> fix_loop` (`resume`) gate opened on whatever prompt arrived
+next, with the entire recon+audit+merge context intact. Silent, and it *looked*
+like success (`status` printed `resume: ready`).
+
+Root cause is a category error about what the hook event means:
+`UserPromptSubmit` answers "did a turn begin?", not "was the context wiped?".
+Fix moves the write to a new `SessionStart` hook, which is **host-driven** (no
+tool call can produce one, so an agent cannot manufacture the evidence) and
+carries `source`, which names *how* the session started.
+
+Full design + spec citations: `docs/superpowers/plans/2026-07-25-issue-79-context-reset-provenance.md`.
+
+- `enforcement/hooks/session_start.py` (new, trusted caller): records
+  `context_reset` only for `source ∈ {clear, compact, startup}`. Silent on
+  success; emits AUDIT TERMINATED / ENFORCEMENT FAILURE on a failed write.
+- **`startup` included deliberately** — the issue suggested `{clear, compact}`.
+  A user who quits and relaunches at `awaiting_clear` has a genuinely empty
+  context; refusing it would trade #79 for #73's failure mode (unsatisfiable
+  gate). `resume`/`fork` excluded: both carry the prior transcript forward.
+- `events.toml`: `trigger` pattern narrowed `^user_prompt_submit$` →
+  `^session_start$`, plus a required `source` patterned to the reset sources.
+  The daemon validates fields on `record_event`, so the old provenance is now
+  **unwritable**, not merely unused.
+- `transitions.toml`: `resume` gate gained `filter = { trigger = "session_start" }`.
+  Block condition ≡ evidence; `user_prompt_submit` events already in live
+  ledgers cannot satisfy it.
+- `primer.py`: stopped recording. Its two failure signals used to be side
+  effects of that write, so they were replaced with direct probes — init-PID
+  liveness (strictly better: no longer needs a write to fail) and a
+  non-mutating `enforcement_read`.
+- `_common.py`: added `DaemonError(RuntimeError)` carrying the wire `error`
+  code. `_daemon_request` was collapsing every refusal into the prose message,
+  which would have forced the probe to string-match `"caller not authenticated"`
+  — the brittle-mirror pattern that caused #77. Subclassing RuntimeError keeps
+  every existing handler unchanged.
+
+**No sahjhan change needed.** Every primitive already ships in 0.19.0:
+`restricted` events + the daemon `record_event` op, per-field pattern validation
+(`handle_record_event` → `validate_event_fields`), and `ledger_has_event_since`
+with a payload `filter` (`entry_matches_filter`). Teaching the engine about
+`SessionStart`/`source` would push Claude Code host-lifecycle semantics into a
+generic state machine — the pollution the project forbids.
+
+Verified: `session_start.py` run against a live real daemon authenticated as
+`hooks/session_start.py` and appended `context_reset` with
+`trigger=session_start, source=clear` to the run-1 ledger (daemon log
+`recorded: context_reset`; fields read back from the ledger). 3 real-daemon
+tests, 13 hook_e2e tests, 6 declarative-config tests. Full suite + coverage
+gate, ruff, mypy, contract gate all observed green.
+NOT run: a full end-to-end audit through an actual `/clear` boundary in a live
+Claude Code session — the SessionStart wiring is verified by hook subprocess +
+real daemon, not by an observed live clear.
+
+## Test/verify commands (holtz)
+```
+source .venv/bin/activate
+python3 -m pytest -q                    # fast (subagents)
+ruff check .
+mypy --explicit-package-bases skills/holtz/scripts/ hooks/ enforcement/hooks/ scripts/ enforcement/scripts/
+python3 scripts/contract_gate.py
+```
+sahjhan binary for empirical gate/SQL checks:
+`/Users/jonr/Documents/code/holtz/.claude-plugin/bin/sahjhan-aarch64-apple-darwin`
+`sahjhan --config-dir <holtz>/enforcement query "<SQL>"` (needs an init'd ledger;
+record events with `event <type> --field ...`; auditor must be holtz|justine,
+commit_hash `^[0-9a-f]{7,40}$`, finding_resolved needs phase/step/id/commit_hash/
+evidence_path).
+</content>

--- a/docs/superpowers/plans/2026-07-25-issue-79-context-reset-provenance.md
+++ b/docs/superpowers/plans/2026-07-25-issue-79-context-reset-provenance.md
@@ -1,0 +1,179 @@
+# Issue #79 — `awaiting_clear` gate satisfied without a real `/clear`
+
+**Status:** in progress
+**Issue:** [jbrjake/holtz#79](https://github.com/jbrjake/holtz/issues/79) (bug, P1)
+**Reported against:** plugin 0.138.2
+
+## The bug in one line
+
+`context_reset` is recorded iff *a prompt was submitted*. It is documented,
+gated, and reasoned about as if it were recorded iff *the context was actually
+reset*.
+
+## Root cause
+
+`enforcement/hooks/primer.py` runs on `UserPromptSubmit` and records
+`context_reset` unconditionally on that path. `UserPromptSubmit` fires for:
+
+- any typed message that is not a `/clear`, and
+- automated background-task notifications delivered as a user turn
+  (this is what tripped the reporter on a live run).
+
+So the first `UserPromptSubmit` after `fix_loop_start` opens the
+`awaiting_clear -> fix_loop` (`resume`) gate regardless of whether a reset
+happened. The `"after /clear"` in the `events.toml` description is an
+assumption the code never checked.
+
+The failure is silent and *looks like success*: `status` prints
+`resume: ready`, so nothing signals that the loop is about to start carrying
+the full recon+audit+merge context — the exact state the boundary exists to
+prevent.
+
+## The signal that actually means "context was reset"
+
+Claude Code's `SessionStart` hook (spec: https://code.claude.com/docs/en/hooks,
+verified 2026-07-25) fires only when the host starts or restarts a session, and
+carries a `source` field:
+
+| `source`  | Fires on                                                        | Prior context |
+|-----------|-----------------------------------------------------------------|---------------|
+| `startup` | new session                                                     | **gone**      |
+| `clear`   | `/clear`                                                        | **gone**      |
+| `compact` | auto or manual compaction                                       | **replaced by a summary** |
+| `resume`  | `--resume`, `--continue`, `/resume`                             | restored      |
+| `fork`    | `--fork-session`, `/fork` background copy, `/branch`            | carried over  |
+
+Two properties make this the right source of truth:
+
+1. It is **host-driven**. An agent cannot start, clear, compact, or fork its
+   own session — no tool call produces a `SessionStart`. Contrast
+   `UserPromptSubmit`, which a background subagent's completion notification
+   produces with no human involved.
+2. It is **self-describing**. `source` distinguishes a real wipe from a
+   restore, so the recorded event can carry its own provenance and the gate
+   can require it.
+
+`startup` is included deliberately. Excluding it would trade #79 (a gate
+satisfied when it shouldn't be) for #73's failure mode (a gate that cannot be
+satisfied): a user who quits and relaunches Claude Code at `awaiting_clear` has
+a genuinely empty context but no way to prove it. `resume` and `fork` are
+excluded because both carry the prior transcript forward.
+
+## Design
+
+**Invariant to restore:** `context_reset` is recorded **iff** the context was
+actually reset.
+
+1. **New hook `enforcement/hooks/session_start.py`** (`SessionStart`).
+   Records `context_reset` when `source ∈ {clear, compact, startup}` and an
+   active non-terminal run exists. Silent on success (token discipline — the
+   primer's banner already reports position on the next turn); speaks only on
+   failure.
+2. **`primer.py` stops recording.** Resume-context injection stays on
+   `UserPromptSubmit` (harmless to re-inject, and it is where the agent needs
+   it).
+3. **`events.toml` encodes the provenance.** `trigger` pattern narrows from
+   `^user_prompt_submit$` to `^session_start$`; a new required `source` field
+   is patterned `^(clear|compact|startup)$`. The engine validates event fields
+   against the consumer's `events.toml` on the daemon `record_event` path, so
+   a `context_reset` claiming a bogus provenance is refused at write time.
+4. **`transitions.toml` requires the provenance.** The `resume` gate gains
+   `filter = { trigger = "session_start" }`. Block condition and evidence are
+   now the same fact — an event recorded on any other path cannot satisfy it,
+   including the `user_prompt_submit` events already sitting in live ledgers.
+
+### Preserving the primer's failure signals
+
+Today the primer detects two failures *as a side effect* of the record attempt:
+
+- daemon death (record raises → init PID dead → write `terminated` marker), and
+- broken caller auth (record raises → PID alive → `ENFORCEMENT FAILURE` banner).
+
+Removing the write would silently drop both. They are replaced with direct,
+non-mutating probes that run on every `UserPromptSubmit`:
+
+- **Death:** read the init PID and signal-0 it. This is strictly better than
+  before — it no longer depends on a write happening to fail.
+- **Auth:** an `enforcement_read` request over the daemon socket. A reachable
+  daemon that rejects the peer answers `caller not authenticated`, which is
+  exactly the trusted-callers failure mode that
+  [[trusted-callers-manifest-regen]] describes; socket-unreachable and
+  no-state-stored are distinguished from it and stay quiet.
+
+The same two banners are emitted from `session_start.py`, where the write now
+lives.
+
+## Why no sahjhan change
+
+Checked, and none is needed — every primitive this fix relies on already ships
+in 0.19.0:
+
+- `restricted = true` events + the daemon `record_event` op (`>= 0.15.0`)
+- per-field pattern validation on `record_event`
+  (`handle_record_event` → `validate_event_fields`)
+- `ledger_has_event_since` with a payload `filter`
+  (`src/gates/ledger.rs`, `entry_matches_filter`)
+
+Everything #79 needs is holtz **domain** config plus a holtz hook. Teaching
+sahjhan about `SessionStart` / `source` would push Claude Code host-lifecycle
+semantics into a generic state-machine engine — the pollution the project
+explicitly forbids. The engine's job here is to validate a declared event
+schema and evaluate a declared filter; it already does both.
+
+## Risk considered: what if `SessionStart` never fires?
+
+Making the gate honest also makes it a hard dependency: if a host never fires
+`SessionStart` for plugin hooks, `awaiting_clear` deadlocks permanently — #73's
+failure mode. No escape hatch was added, because any escape hatch is a route
+around the boundary and defeats the fix.
+
+Accepted because the dependency is narrower than ones the plugin already has.
+`SessionStart` with `source` is long-standing and documented as supported in
+plugin `hooks/hooks.json`; the schema this repo already validates against uses
+much newer surface (the `defer` permission decision, the `fork` source). A host
+new enough to run the existing enforcement chain fires `SessionStart`.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `enforcement/hooks/session_start.py` | **new** — records `context_reset` on a real reset |
+| `enforcement/hooks/primer.py` | drop the write; direct death + auth probes |
+| `hooks/hooks.json` | register the `SessionStart` hook |
+| `enforcement/hooks-manifest.json` | require it |
+| `enforcement/events.toml` | `trigger` → `^session_start$`; add `source` |
+| `enforcement/transitions.toml` | `resume` gate filter; correct the comment |
+| `scripts/hash-trusted-callers.sh` | add `session_start.py` |
+| `enforcement/trusted-callers.toml` | regenerate |
+| `skills/holtz/references/phase-fix-loop.md` | correct the HARD-GATE claim |
+| `tests/test_session_start.py` | **new** — `hook_e2e` provenance coverage |
+| `tests/test_primer.py`, `tests/test_sahjhan_integration.py` | move reset coverage |
+
+## Test plan
+
+Per CLAUDE.md testing methodology — hooks are tested by **subprocess**, which is
+the interface Claude Code actually uses.
+
+1. `hook_e2e`: `session_start.py` records `context_reset` for `clear`,
+   `compact`, `startup`; records **nothing** for `resume`, `fork`, an absent
+   `source`, and an unknown source.
+2. `hook_e2e`: recorded fields carry `trigger=session_start` and the real
+   `source`.
+3. `hook_e2e`: `primer.py` records **no** `context_reset` for any
+   `UserPromptSubmit` — the #79 regression guard.
+4. `hook_e2e`: primer still writes the `terminated` marker on a dead init PID,
+   and still surfaces `ENFORCEMENT FAILURE` on a reachable-but-rejecting daemon.
+5. Config: the `resume` gate filters on `trigger`, and `events.toml` cannot
+   express `user_prompt_submit`.
+6. No-audit / terminated-audit paths stay silent and never bootstrap the binary.
+
+## Verification (observed evidence required — no future-tense claims)
+
+- [ ] `pytest -m hook_e2e` exit 0
+- [ ] full `pytest` with coverage gate exit 0
+- [ ] `ruff check .` exit 0
+- [ ] `mypy` exit 0
+- [ ] `python3 scripts/contract_gate.py` exit 0
+- [ ] `scripts/pre-release-check.sh` exit 0
+- [ ] CI green on dev (`gh run view <id>` → `conclusion=success`)
+- [ ] release PR CI green before merge

--- a/enforcement/events.toml
+++ b/enforcement/events.toml
@@ -115,14 +115,21 @@ fields = [
     { name = "detail", type = "string" },
 ]
 
+# Context boundary. `trigger` and `source` are patterned, not decorative: they
+# are the event's provenance, and the daemon validates them on every write. An
+# event that cannot name a real context reset cannot be recorded, and the
+# `resume` gate filters on `trigger` so it cannot be satisfied by one (#79).
+# `startup`/`clear`/`compact` wipe or replace the context; `resume`/`fork`
+# carry the prior transcript forward and are therefore not resets.
 [events.context_reset]
-description = "Context boundary — recorded by primer hook on UserPromptSubmit after /clear"
+description = "Context boundary — recorded by session_start hook when Claude Code reports a real context reset (SessionStart source=clear|compact|startup)"
 restricted = true
 fields = [
     { name = "project", type = "string" },
     { name = "run", type = "string", pattern = "^\\d+$" },
     { name = "auditor", type = "string", pattern = "^(holtz|justine)$" },
-    { name = "trigger", type = "string", pattern = "^user_prompt_submit$" },
+    { name = "trigger", type = "string", pattern = "^session_start$" },
+    { name = "source", type = "string", pattern = "^(clear|compact|startup)$" },
 ]
 
 [events.justine_dispatched]

--- a/enforcement/hooks-manifest.json
+++ b/enforcement/hooks-manifest.json
@@ -3,6 +3,7 @@
     "PreToolUse": ["_daemon_lifecycle.py", "_sahjhan_bootstrap.py", "pre_tool_hook.py", "commit_gate.py"],
     "PostToolUse": ["post_tool_hook.py", "bash_guard.py", "protocol_tracker.py", "quiz_capture.py"],
     "UserPromptSubmit": ["primer.py"],
+    "SessionStart": ["session_start.py"],
     "Stop": ["stop_hook.py"],
     "SubagentStop": ["lens_quiz.py", "subagent_findings_check.py"]
   }

--- a/enforcement/hooks/_common.py
+++ b/enforcement/hooks/_common.py
@@ -169,10 +169,30 @@ def _get_daemon_socket_path(cwd: str | None = None) -> str:
     return os.path.join(cwd, "docs", "holtz", ".sahjhan", "daemon.sock")
 
 
+class DaemonError(RuntimeError):
+    """A request that reached the daemon and was refused by it.
+
+    The wire protocol answers with a structured ``error`` code alongside the
+    human-readable ``message``, but this was collapsing both into a bare
+    ``RuntimeError(message)``. Callers that need to tell refusals apart —
+    ``auth_failed`` means enforcement is broken, ``not_found`` just means
+    nothing is stored yet — were left with nothing but the prose to match on.
+    Subclasses RuntimeError, so every existing ``except RuntimeError`` handler
+    behaves exactly as before.
+    """
+
+    def __init__(self, message: str, error: str = "", reason: str = "") -> None:
+        super().__init__(message)
+        self.error = error
+        self.reason = reason
+
+
 def _daemon_request(sock_path: str, request: dict) -> dict:
     """Send a JSON request to the sahjhan daemon and return the response.
 
-    Raises RuntimeError if the daemon is unreachable or returns an error.
+    Raises DaemonError (a RuntimeError) if the daemon refuses the request, and
+    OSError if the socket is unreachable. The two are different facts: a
+    refusal proves the daemon is alive.
     """
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.settimeout(5)
@@ -183,8 +203,10 @@ def _daemon_request(sock_path: str, request: dict) -> dict:
     finally:
         sock.close()
     if not response.get("ok"):
-        raise RuntimeError(
-            f"sahjhan daemon error: {response.get('message', 'unknown error')}"
+        raise DaemonError(
+            f"sahjhan daemon error: {response.get('message', 'unknown error')}",
+            error=str(response.get("error") or ""),
+            reason=str(response.get("reason") or ""),
         )
     return response
 

--- a/enforcement/hooks/primer.py
+++ b/enforcement/hooks/primer.py
@@ -3,12 +3,19 @@
 
 When there's an active non-terminal Sahjhan run, this hook:
 1. Checks for terminated audit (daemon died)
-2. Records a context_reset event (used by awaiting_clear gate)
+2. Checks that enforcement can still reach and authenticate to the daemon
 3. Injects current protocol state as additional context
 
 If the daemon is dead and the init PID confirms death, writes a
 terminated marker and injects a termination message. No restart
 attempts — a new daemon has a new key, the old ledger is sealed.
+
+This hook deliberately does NOT record `context_reset`. It used to, on every
+UserPromptSubmit — but UserPromptSubmit fires on ordinary typed messages and on
+automated background-task notifications, neither of which resets anything, so
+the awaiting_clear -> fix_loop gate opened with the full pre-reset context
+intact (#79). That event now comes from session_start.py, where the host tells
+us a reset actually happened.
 """
 from __future__ import annotations
 
@@ -19,18 +26,43 @@ import sys
 sys.path.insert(0, os.path.dirname(__file__))
 
 from _common import (  # noqa: E402
+    DaemonError,
+    _daemon_request,
+    _get_daemon_socket_path,
     _is_process_alive,
     _read_init_pid,
     _write_terminated_marker,
     exit_ok,
     exit_warn,
     read_event,
-    record_authed_event,
     resolve_config_dir,
 )
 from _protocol_cache import format_state_line, parse_status_text  # noqa: E402
 from _protocol_cache import read_cache as read_enforcement_cache
 from _resolve import ensure_sahjhan  # noqa: E402
+
+
+def _enforcement_healthy(cwd: str) -> bool:
+    """Probe the daemon over its socket without touching the ledger.
+
+    The removed `context_reset` write used to prove this as a side effect: it
+    failed loudly when the daemon was unreachable or when this hook's hash no
+    longer matched trusted-callers.toml (which otherwise fails open and
+    silently disables every gate). `enforcement_read` is the cheapest op
+    behind the same peer-identity check, and it is a read — so keeping the
+    signal costs no protocol state.
+
+    A `not_found` refusal is healthy: the daemon authenticated this caller
+    before dispatching the op, and an audit that hasn't written its cache yet
+    simply has nothing stored. Only an authorization refusal is a failure.
+    """
+    try:
+        _daemon_request(_get_daemon_socket_path(cwd), {"op": "enforcement_read"})
+    except DaemonError as exc:
+        return exc.error != "auth_failed"
+    except (OSError, ConnectionError, RuntimeError, ValueError):
+        return False
+    return True
 
 
 def main() -> None:
@@ -88,7 +120,6 @@ def main() -> None:
     if is_terminal or not current_state:
         exit_ok()
 
-    # Record context_reset event (gates awaiting_clear -> fix_loop)
     run_number = status.get("run_number", "0")
     if run_number == "0":
         # Fallback: read sahjhan's active-ledger marker directly
@@ -98,30 +129,22 @@ def main() -> None:
                 run_number = f.read().strip().replace("run-", "") or "0"
         except OSError:
             pass
-    context_reset_failed = False
+
+    # Enforcement health. Death is checked directly rather than inferred from a
+    # failed write, so a daemon that dies between turns is caught on the next
+    # prompt whether or not anything happened to need the socket.
+    enforcement_failed = False
     audit_terminated = False
-    try:
-        record_authed_event(
-            "context_reset",
-            {
-                "project": "holtz",
-                "run": run_number,
-                "auditor": "holtz",
-                "trigger": "user_prompt_submit",
-            },
-            cwd=cwd,
-        )
-    except (OSError, subprocess.TimeoutExpired, RuntimeError):
-        # Don't restart. Check if daemon init PID is dead.
-        init_pid = _read_init_pid(cwd)
-        if init_pid is not None and not _is_process_alive(init_pid):
-            _write_terminated_marker(cwd, init_pid, detected_by="primer")
-            audit_terminated = True
-        context_reset_failed = True
+    init_pid = _read_init_pid(cwd)
+    if init_pid is not None and not _is_process_alive(init_pid):
+        _write_terminated_marker(cwd, init_pid, detected_by="primer")
+        audit_terminated = True
+    elif not _enforcement_healthy(cwd):
+        enforcement_failed = True
 
     if audit_terminated:
         exit_warn(
-            "AUDIT TERMINATED: daemon died during awaiting_clear — session key lost. "
+            f"AUDIT TERMINATED: daemon died during {current_state} — session key lost. "
             "The ledger is unwritable. This audit cannot be completed. "
             "Check /tmp/sahjhan-daemon.log for crash output. "
             "A new daemon has a new key and cannot resume this ledger. "
@@ -166,11 +189,12 @@ def main() -> None:
     if state_line:
         context += "\n" + state_line
 
-    if context_reset_failed:
+    if enforcement_failed:
         context += (
             "\n\n⛔ ENFORCEMENT FAILURE — STOP IMMEDIATELY\n\n"
-            "Daemon authentication failed. The context_reset event cannot be recorded, "
-            "which means protocol gates are permanently blocked for this session.\n\n"
+            "The sahjhan daemon is unreachable or rejected this hook. Restricted "
+            "events cannot be recorded, which means protocol gates are permanently "
+            "blocked for this session.\n\n"
             "This is an unrecoverable state. Do NOT attempt to:\n"
             "- Reset the ledger (sahjhan reset)\n"
             "- Modify .sahjhan/ contents directly\n"

--- a/enforcement/hooks/session_start.py
+++ b/enforcement/hooks/session_start.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Sahjhan session-start hook — records context_reset on a REAL context reset.
+
+`context_reset` gates `awaiting_clear -> fix_loop` (the `resume` transition):
+the punchlist is built in one context, the fixes happen in another. That gate
+is only worth anything if the event behind it means what it says.
+
+It used to be recorded by primer.py on every `UserPromptSubmit`, which fires on
+ordinary typed messages and on automated background-task notifications alike —
+so the gate opened on whatever prompt happened to arrive next, with the full
+pre-reset context intact (#79).
+
+`SessionStart` is the event that actually corresponds to a wiped context. It is
+host-driven — no tool call can produce one, so an agent cannot manufacture the
+evidence — and its `source` field says *how* the session started, which is what
+separates a real reset from a restore:
+
+    startup  new session ............................ context is empty
+    clear    /clear ................................. context is wiped
+    compact  auto or manual compaction .............. context replaced by a summary
+    resume   --resume / --continue / /resume ........ prior transcript RESTORED
+    fork     --fork-session / /fork / /branch ....... prior transcript CARRIED OVER
+
+Only the first three are recorded. `startup` counts: a user who quits and
+relaunches at `awaiting_clear` has a genuinely empty context, and refusing it
+would trade #79 for an unsatisfiable gate (#73's failure mode).
+
+Silent on success — the primer's resume banner reports position on the next
+turn, so saying it twice is wasted context. Speaks only when the event could
+not be recorded, because a `context_reset` that never landed means the run
+cannot leave `awaiting_clear`.
+
+Spec: https://code.claude.com/docs/en/hooks (verified 2026-07-25)
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from _common import (  # noqa: E402
+    _is_process_alive,
+    _read_init_pid,
+    _write_terminated_marker,
+    exit_ok,
+    exit_warn,
+    read_event,
+    record_authed_event,
+    resolve_config_dir,
+)
+from _protocol_cache import parse_status_text  # noqa: E402
+from _resolve import ensure_sahjhan  # noqa: E402
+
+# SessionStart `source` values that mean the prior context is gone.
+# `resume` and `fork` are excluded: both carry the transcript forward.
+RESET_SOURCES = frozenset({"clear", "compact", "startup"})
+
+_TERMINATED_MSG = (
+    "AUDIT TERMINATED: daemon died — session key lost. "
+    "The ledger is unwritable. This audit cannot be completed. "
+    "Check /tmp/sahjhan-daemon.log for crash output. "
+    "A new daemon has a new key and cannot resume this ledger. "
+    "Disable the plugin with /plugin to restore tool access; "
+    "to start a new audit, remove docs/holtz/.sahjhan/ first."
+)
+
+_AUTH_FAILURE_MSG = (
+    "⛔ ENFORCEMENT FAILURE — STOP IMMEDIATELY\n\n"
+    "Daemon authentication failed. The context_reset event for this session "
+    "could not be recorded, so the awaiting_clear -> fix_loop gate cannot be "
+    "satisfied for this run.\n\n"
+    "This is an unrecoverable state. Do NOT attempt to:\n"
+    "- Reset the ledger (sahjhan reset)\n"
+    "- Modify .sahjhan/ contents directly\n"
+    "- Work around the blocked gate\n\n"
+    "Report this failure to the user and wait for instructions."
+)
+
+
+def _run_number(status: dict, data_dir: str) -> str:
+    """Resolve the active run number for the event payload.
+
+    Prefers `sahjhan status`; falls back to sahjhan's active-ledger marker,
+    same as the primer did.
+    """
+    run_number = status.get("run_number", "0")
+    if run_number != "0":
+        return str(run_number)
+    try:
+        with open(os.path.join(data_dir, "active-ledger"), encoding="utf-8") as f:
+            return f.read().strip().replace("run-", "") or "0"
+    except OSError:
+        return "0"
+
+
+def main() -> None:
+    event = read_event()
+    cwd = event.get("cwd", os.getcwd())
+
+    # Not a context reset — a restored or forked session keeps its transcript.
+    # Checked before anything else so `resume`/`fork` cost nothing.
+    if event.get("source", "") not in RESET_SOURCES:
+        exit_ok()
+
+    # No active run — nothing to record. Checked BEFORE ensure_sahjhan() so
+    # projects without an audit don't trigger the ~100MB binary download at
+    # session start.
+    data_dir = os.path.join(cwd, "docs", "holtz", ".sahjhan")
+    if not os.path.isdir(data_dir):
+        exit_ok()
+
+    # Terminated audit — the primer announces it on the next prompt. Saying it
+    # here too would just double the banner.
+    if os.path.isfile(os.path.join(data_dir, "terminated")):
+        exit_ok()
+
+    binary = ensure_sahjhan()
+    if binary is None:
+        exit_ok()
+
+    config_dir, _ = resolve_config_dir(cwd)
+
+    try:
+        result = subprocess.run(
+            [binary, "--config-dir", config_dir, "status"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        exit_ok()
+
+    if result.returncode != 0:
+        exit_ok()
+
+    status = parse_status_text(result.stdout)
+    if status.get("terminal", False) or not status.get("current_state", ""):
+        exit_ok()
+
+    try:
+        record_authed_event(
+            "context_reset",
+            {
+                "project": "holtz",
+                "run": _run_number(status, data_dir),
+                "auditor": "holtz",
+                "trigger": "session_start",
+                "source": event["source"],
+            },
+            cwd=cwd,
+        )
+    except (OSError, subprocess.TimeoutExpired, RuntimeError):
+        # Don't restart the daemon — a new one has a new key and the old
+        # ledger is sealed. Distinguish death from a live-but-rejecting daemon.
+        init_pid = _read_init_pid(cwd)
+        if init_pid is not None and not _is_process_alive(init_pid):
+            _write_terminated_marker(cwd, init_pid, detected_by="session_start")
+            exit_warn(_TERMINATED_MSG, "SessionStart")
+        exit_warn(_AUTH_FAILURE_MSG, "SessionStart")
+
+    exit_ok()
+
+
+if __name__ == "__main__":
+    main()

--- a/enforcement/states.toml
+++ b/enforcement/states.toml
@@ -21,7 +21,9 @@ params = [{ name = "current_perspective", set = "perspective", source = "current
 
 [states.awaiting_clear]
 label = "Awaiting Context Reset"
-# Agent must tell user to /clear; primer hook records context_reset event
+# Agent must tell the user to /clear. Claude Code then fires SessionStart, and
+# session_start.py records the context_reset event that unblocks `resume`.
+# Nothing an agent can do produces that event — waiting is the only way out.
 
 [states.awaiting_human]
 label = "Awaiting Human (paused)"

--- a/enforcement/transitions.toml
+++ b/enforcement/transitions.toml
@@ -46,10 +46,11 @@ gates = [
 
 # fix_loop_start lands in awaiting_clear, NOT fix_loop: the punchlist is now
 # built (merge complete / audit pass done), and the agent MUST /clear before
-# touching any fix. The `resume` transition below (gated on context_reset)
-# carries awaiting_clear -> fix_loop, so a real context reset is enforced
-# between building the worklist and the first fix — the same machinery that
-# gates the per-iteration clears inside the loop.
+# touching any fix. The `resume` transition below carries awaiting_clear ->
+# fix_loop, gated on a `context_reset` that Claude Code's SessionStart hook
+# vouched for — so a real context reset is enforced between building the
+# worklist and the first fix, by the same machinery that gates the
+# per-iteration clears inside the loop.
 [[transitions]]
 from = "merge_done"
 to = "awaiting_clear"
@@ -148,12 +149,19 @@ gates = [
     { type = "query", sql = "SELECT count(*) < 3 FROM events WHERE type='state_transition' AND command='fix_commit' AND seq > COALESCE((SELECT MAX(seq) FROM events WHERE type='pattern_analysis_complete'), 0)", expect = "true", intent = "pattern analysis required after 3+ fixes — run pattern_check before iteration_boundary" },
 ]
 
+# The filter is what makes this gate mean what it says. `context_reset` used to
+# be recorded by the primer on every UserPromptSubmit — including automated
+# background-task notifications — so the gate opened on whatever prompt arrived
+# next, with the pre-reset context fully intact (#79). Only session_start.py can
+# write `trigger=session_start`, and only when Claude Code reports a SessionStart
+# whose source actually wiped the context. Requiring the provenance here means
+# the block condition and the evidence are the same fact.
 [[transitions]]
 from = "awaiting_clear"
 to = "fix_loop"
 command = "resume"
 gates = [
-    { type = "ledger_has_event_since", event = "context_reset", since = "last_transition", intent = "context must be reset via /clear before resuming" },
+    { type = "ledger_has_event_since", event = "context_reset", since = "last_transition", filter = { trigger = "session_start" }, intent = "context must be reset via /clear (or compaction) before resuming" },
 ]
 
 # ── Pause for human (#69) ──

--- a/enforcement/trusted-callers.toml
+++ b/enforcement/trusted-callers.toml
@@ -11,10 +11,11 @@
 # CI gate: the pre-commit hook verifies this manifest is up to date.
 
 [callers]
-"hooks/_common.py" = "sha256:6e2a731ad0a23d4c685d073707ebf28167d7da0f7de13600b0a86fc2e7a876d8"
+"hooks/_common.py" = "sha256:06674db55a1f611b9508d959ef93fa6c8f6a8c41e725a36766fd75cd9d06bc28"
 "hooks/lens_quiz.py" = "sha256:adcdf6336412dcc1e3dd8f3d181362c37cf84ec2f8e83cbeaadbe486a05eb991"
 "hooks/stop_hook.py" = "sha256:1c8645eb0610db19dee54c0ffa43a64073c994dd926053215018434e54af2653"
-"hooks/primer.py" = "sha256:cc933b70db32c93dc3b1b257f056f61d0ca7a99ba3f140929e1954eee010fcff"
+"hooks/primer.py" = "sha256:769d90443822c4264548b7c8cfe57657db22b4bfb631386a4850ddabc38381a6"
+"hooks/session_start.py" = "sha256:4f542356f2961f6b601668bafe79517b89ff1c358a6e411ce3bd4f6d18ab6dea"
 "hooks/pre_tool_hook.py" = "sha256:d586c691519d0fe10c14c44c3a32b710be95f5b830689637353985e7ed56ef96"
 "hooks/post_tool_hook.py" = "sha256:63e513159f24f79c3d23bac2d30a77e315b9905c578472dde0329e52c1918947"
 "hooks/commit_gate.py" = "sha256:e1b26fae9dace0e9556fdad292eb34e102b2a3f03d705beaed4e28145458b840"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -110,6 +110,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/enforcement/hooks/session_start.py\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/scripts/hash-trusted-callers.sh
+++ b/scripts/hash-trusted-callers.sh
@@ -18,6 +18,7 @@ TRUSTED_SCRIPTS=(
     "enforcement/hooks/lens_quiz.py"
     "enforcement/hooks/stop_hook.py"
     "enforcement/hooks/primer.py"
+    "enforcement/hooks/session_start.py"
     "enforcement/hooks/pre_tool_hook.py"
     "enforcement/hooks/post_tool_hook.py"
     "enforcement/hooks/commit_gate.py"

--- a/scripts/refresh_hook_schema.py
+++ b/scripts/refresh_hook_schema.py
@@ -22,6 +22,8 @@ from hook_schema import (  # noqa: E402
     POSTTOOLUSE_VALID_DECISIONS,
     PRETOOLUSE_HSO_FIELDS,
     PRETOOLUSE_VALID_DECISIONS,
+    SESSIONSTART_HSO_FIELDS,
+    SESSIONSTART_SOURCES,
     STOP_VALID_DECISIONS,
     UNIVERSAL_FIELDS,
     USERPROMPTSUBMIT_HSO_FIELDS,
@@ -73,6 +75,14 @@ def generate_schema() -> dict:
             "required_wrapper_key": None,
             "valid_top_level_decisions": sorted(USERPROMPTSUBMIT_VALID_DECISIONS),
             "hookSpecificOutput_fields": sorted(USERPROMPTSUBMIT_HSO_FIELDS),
+            "universal_fields": sorted(UNIVERSAL_FIELDS),
+        },
+        "SessionStart": {
+            "required_wrapper_key": None,
+            "valid_top_level_decisions": [],
+            "hookSpecificOutput_fields": sorted(SESSIONSTART_HSO_FIELDS),
+            "forbidden_fields": ["decision"],
+            "sources": sorted(SESSIONSTART_SOURCES),
             "universal_fields": sorted(UNIVERSAL_FIELDS),
         },
     }

--- a/scripts/smoke-test-hooks.sh
+++ b/scripts/smoke-test-hooks.sh
@@ -41,6 +41,7 @@ enforcement/hooks/bash_guard.py:PostToolUse
 enforcement/hooks/protocol_tracker.py:PostToolUse
 enforcement/hooks/stop_hook.py:Stop
 enforcement/hooks/primer.py:UserPromptSubmit
+enforcement/hooks/session_start.py:SessionStart
 hooks/subagent_findings_check.py:SubagentStop
 "
 
@@ -64,6 +65,13 @@ for entry in $HOOKS; do
         MATCHER="*"
         PROMPT="say hi"
     elif [[ "$event" == "UserPromptSubmit" ]]; then
+        MATCHER="*"
+        PROMPT="say hi"
+    elif [[ "$event" == "SessionStart" ]]; then
+        # A fresh `claude -p` run fires SessionStart (source=startup). Like the
+        # other entries here this only proves the hook is invoked and emits
+        # valid JSON — the work dir has no audit, so the hook exits silently.
+        # Provenance behavior is covered by tests/test_session_start.py.
         MATCHER="*"
         PROMPT="say hi"
     elif [[ "$event" == "SubagentStop" ]]; then

--- a/skills/holtz/SKILL.md
+++ b/skills/holtz/SKILL.md
@@ -236,7 +236,7 @@ If you catch yourself thinking any of these, STOP. You are rationalizing non-com
 - **Terse within phases.** Between tool calls within a phase, do not explain what you are about to do. Execute, then report findings. Save narrative for phase boundaries and significant discoveries. Every sentence of narration enters context permanently.
 - **Tool search threshold.** In MCP-heavy environments, set `ENABLE_TOOL_SEARCH=auto:5` to defer tool definition loading until tools exceed 5% of context (default is 10%). This reduces early-session cache burden when many MCP servers are connected.
 - **Re-read before every step.** At the start of each step, read the output files you need. Assume prior context is gone.
-- **After compaction or `/clear`: STOP.** Run `sahjhan status` and re-read the latest step output files before continuing. After `/clear`, the primer hook injects resume context automatically and records a `context_reset` event in the ledger.
+- **After compaction or `/clear`: STOP.** Run `sahjhan status` and re-read the latest step output files before continuing. Claude Code's `SessionStart` records the `context_reset` event, and the primer injects resume context on your next turn.
 - **The Sahjhan ledger is your program counter.** Run `sahjhan status` after any compaction to recover your position — current state, active perspective, available transitions. The rendered STATUS.md is a read-only view of this same data.
 
 ## Session Splitting (Optional, for Token Efficiency)

--- a/skills/holtz/references/phase-convergence.md
+++ b/skills/holtz/references/phase-convergence.md
@@ -18,7 +18,7 @@ All sahjhan commands below must include `--config-dir "$CLAUDE_PLUGIN_ROOT/enfor
 6. If not converged for other reasons: run `sahjhan --config-dir "$CLAUDE_PLUGIN_ROOT/enforcement" ledger checkpoint --snapshot pre-clear` then `sahjhan --config-dir "$CLAUDE_PLUGIN_ROOT/enforcement" transition iteration_boundary`. Tell the user: *"Not converged. `/clear` then any message to continue."* Stop. The stop gate hook enforces this: blocks premature stops until the protocol reaches a terminal state.
 7. If converged: run `sahjhan --config-dir "$CLAUDE_PLUGIN_ROOT/enforcement" transition confirm_convergence` — transitions from `final_sweep_clean` to `converged`. Proceed to Step 16.
 
-After `/clear`, the primer hook injects resume context and records a `context_reset` event — the user types anything and the model resumes from `sahjhan status`.
+After `/clear`, Claude Code's `SessionStart` records the `context_reset` event and the primer injects resume context — the user types anything and the model resumes from `sahjhan status`.
 
 **Filtered reads in convergence loop:** Each iteration re-reads the punchlist. If the punchlist has more than 6 items, use:
 ```bash

--- a/skills/holtz/references/phase-fix-loop.md
+++ b/skills/holtz/references/phase-fix-loop.md
@@ -13,8 +13,10 @@ The `fix_loop_start` transition will not pass without this event.
 
 1. Run `sahjhan --config-dir "$CLAUDE_PLUGIN_ROOT/enforcement" transition fix_loop_start` → you are now in `awaiting_clear`.
 2. Tell the user to `/clear`. The turn stops; the daemon survives (it holds the session key). This is a context reset, **not** a stopping point — the run resumes after the clear.
-3. After `/clear`, the primer re-injects state and records the `context_reset` event. **Re-read [references/step-10-fix-loop.md](references/step-10-fix-loop.md)** (your context was wiped) and the worklist from disk.
-4. Run `sahjhan --config-dir "$CLAUDE_PLUGIN_ROOT/enforcement" transition resume` → now you are in `fix_loop`. The `resume` gate requires the `context_reset`, so it will not pass unless a real `/clear` happened.
+3. After `/clear`, Claude Code fires a `SessionStart` that records the `context_reset` event, and the primer re-injects state on your next turn. **Re-read [references/step-10-fix-loop.md](references/step-10-fix-loop.md)** (your context was wiped) and the worklist from disk.
+4. Run `sahjhan --config-dir "$CLAUDE_PLUGIN_ROOT/enforcement" transition resume` → now you are in `fix_loop`.
+
+The `resume` gate requires a `context_reset` whose provenance is a real reset — `/clear`, a compaction, or a brand-new session. Nothing else can write one: it is not produced by sending a message, and a `--resume`/`--continue`/`/branch` session does not count, because those carry the old context forward. Talking your way past this gate is not available; the only way through is an actual reset (#79).
 
 The same `awaiting_clear` boundary recurs mid-loop via `iteration_boundary` (Step 12). Entering fixes and resuming fixes use identical machinery.
 </HARD-GATE>

--- a/tests/fixtures/hook_output_schema.json
+++ b/tests/fixtures/hook_output_schema.json
@@ -87,5 +87,33 @@
       "suppressOutput",
       "systemMessage"
     ]
+  },
+  "SessionStart": {
+    "required_wrapper_key": null,
+    "valid_top_level_decisions": [],
+    "hookSpecificOutput_fields": [
+      "additionalContext",
+      "hookEventName",
+      "initialUserMessage",
+      "reloadSkills",
+      "sessionTitle",
+      "watchPaths"
+    ],
+    "forbidden_fields": [
+      "decision"
+    ],
+    "sources": [
+      "clear",
+      "compact",
+      "fork",
+      "resume",
+      "startup"
+    ],
+    "universal_fields": [
+      "continue",
+      "stopReason",
+      "suppressOutput",
+      "systemMessage"
+    ]
   }
 }

--- a/tests/hook_schema.py
+++ b/tests/hook_schema.py
@@ -1,7 +1,7 @@
 """Claude Code hook output schema — single source of truth.
 
 Derived from: https://code.claude.com/docs/en/hooks
-Last verified: 2026-04-11
+Last verified: 2026-07-25
 
 ALL test validators and assertions must reference this file.
 When Claude Code changes their spec, update THIS file only.
@@ -46,6 +46,31 @@ USERPROMPTSUBMIT_HSO_FIELDS: set[str] = {
     "sessionTitle",
 }
 
+# ── SessionStart ────────────────────────────────────────────
+# SessionStart cannot block — it is for side effects and context
+# injection only, so there is no decision field at all.
+SESSIONSTART_VALID_DECISIONS: set[str] = set()
+
+SESSIONSTART_HSO_FIELDS: set[str] = {
+    "hookEventName",
+    "additionalContext",
+    "initialUserMessage",
+    "watchPaths",
+    "sessionTitle",
+    "reloadSkills",
+}
+
+# `source` values, i.e. how the session was initiated. Only the first
+# three leave the model with no prior context; `resume` restores the
+# transcript and `fork` copies it (holtz #79).
+SESSIONSTART_SOURCES: set[str] = {
+    "startup",
+    "resume",
+    "clear",
+    "compact",
+    "fork",
+}
+
 # ── Universal top-level fields (all events) ─────────────────
 UNIVERSAL_FIELDS: set[str] = {
     "continue",         # bool, default true. false = stop Claude entirely
@@ -76,6 +101,8 @@ def validate_hook_output(event_type: str, output: dict) -> list[str]:
         errors.extend(_validate_stop(output))
     elif event_type == "UserPromptSubmit":
         errors.extend(_validate_user_prompt_submit(output))
+    elif event_type == "SessionStart":
+        errors.extend(_validate_session_start(output))
 
     return errors
 
@@ -155,5 +182,28 @@ def _validate_user_prompt_submit(output: dict) -> list[str]:
         errors.append(
             f"Invalid UserPromptSubmit decision '{decision}'. Only 'block' is valid."
         )
+
+    return errors
+
+
+def _validate_session_start(output: dict) -> list[str]:
+    errors: list[str] = []
+    hso = output.get("hookSpecificOutput", {})
+
+    if hso:
+        event_name = hso.get("hookEventName")
+        if event_name and event_name != "SessionStart":
+            errors.append(
+                f"hookEventName must be 'SessionStart', got '{event_name}'"
+            )
+        unknown = set(hso.keys()) - SESSIONSTART_HSO_FIELDS
+        if unknown:
+            errors.append(
+                f"Unknown SessionStart hookSpecificOutput fields: {sorted(unknown)}"
+            )
+
+    # SessionStart cannot block — a decision field is always a mistake.
+    if "decision" in output:
+        errors.append("SessionStart cannot block — 'decision' is not a valid field")
 
     return errors

--- a/tests/test_enforcement_config.py
+++ b/tests/test_enforcement_config.py
@@ -672,3 +672,116 @@ def test_trusted_callers_hashes_match_files():
         "trusted-callers.toml is stale. The daemon will reject these callers:\n  "
         + "\n  ".join(mismatches)
     )
+
+
+# ── Issue #79: context_reset provenance is declarative ──
+
+
+def _context_reset_fields() -> dict[str, dict]:
+    cfg = tomllib.loads(EVENTS_TOML.read_text())
+    return {f["name"]: f for f in cfg["events"]["context_reset"]["fields"]}
+
+
+def _resume_gate() -> dict:
+    cfg = tomllib.loads(TRANSITIONS_TOML.read_text())
+    resume = [
+        t for t in cfg["transitions"]
+        if t.get("command") == "resume" and t.get("from") == "awaiting_clear"
+    ]
+    assert len(resume) == 1, "expected exactly one awaiting_clear `resume` transition"
+    gates = resume[0]["gates"]
+    reset_gates = [g for g in gates if g.get("event") == "context_reset"]
+    assert len(reset_gates) == 1, "expected exactly one context_reset gate on resume"
+    return reset_gates[0]
+
+
+def test_context_reset_trigger_cannot_be_a_prompt():
+    """The old provenance must be unwritable, not merely unused (#79).
+
+    The daemon validates event fields against this pattern on every
+    `record_event`, so narrowing it is what stops any future hook — or a
+    revert of primer.py — from recording a prompt as if it were a reset.
+    """
+    pattern = _context_reset_fields()["trigger"]["pattern"]
+    assert not re.match(pattern, "user_prompt_submit"), (
+        f"trigger pattern {pattern!r} still admits 'user_prompt_submit'. "
+        "A submitted prompt is not a context reset."
+    )
+    assert re.match(pattern, "session_start")
+
+
+def test_context_reset_source_admits_only_real_resets():
+    """resume/fork carry the prior transcript forward — they are not resets."""
+    pattern = _context_reset_fields()["source"]["pattern"]
+    for source in ("clear", "compact", "startup"):
+        assert re.match(pattern, source), (
+            f"source pattern {pattern!r} rejects {source!r}, which does wipe "
+            f"or replace the context — this would make the gate unsatisfiable"
+        )
+    for source in ("resume", "fork"):
+        assert not re.match(pattern, source), (
+            f"source pattern {pattern!r} admits {source!r}, which restores or "
+            f"copies the prior context"
+        )
+
+
+def test_context_reset_is_restricted():
+    """Only a hash-verified trusted caller may write the event."""
+    cfg = tomllib.loads(EVENTS_TOML.read_text())
+    assert cfg["events"]["context_reset"].get("restricted") is True
+
+
+def test_resume_gate_requires_session_start_provenance():
+    """The gate must filter on provenance, not just on the event type.
+
+    Without the filter, `context_reset` events already in live ledgers — the
+    ones the primer wrote on ordinary prompts — would still satisfy it.
+    """
+    gate = _resume_gate()
+    assert gate.get("filter", {}).get("trigger") == "session_start", (
+        f"resume gate does not require trigger=session_start: {gate!r}"
+    )
+    assert gate["since"] == "last_transition"
+
+
+def test_session_start_hook_is_registered_and_trusted():
+    """The only writer of context_reset must actually run, and authenticate."""
+    hooks_json = json.loads(
+        (Path(__file__).parent.parent / "hooks" / "hooks.json").read_text()
+    )
+    commands = [
+        h["command"]
+        for group in hooks_json["hooks"].get("SessionStart", [])
+        for h in group["hooks"]
+    ]
+    assert any("session_start.py" in c for c in commands), (
+        "session_start.py is not registered for SessionStart — context_reset "
+        "would never be recorded and every awaiting_clear would deadlock"
+    )
+
+    manifest = tomllib.loads((ENFORCEMENT_DIR / "trusted-callers.toml").read_text())
+    assert "hooks/session_start.py" in manifest["callers"], (
+        "session_start.py is missing from trusted-callers.toml — the daemon "
+        "would reject its record_event and the gate could never open"
+    )
+
+
+def test_ungated_resume_cannot_bypass_the_clear_boundary():
+    """The `awaiting_human` resume is ungated on purpose — keep it unreachable
+    from `awaiting_clear`.
+
+    Pausing to answer a user mid-fix (#69) is always legitimate, so that
+    transition carries no context_reset gate. It shares the `resume` command
+    name with the gated one, which makes it a standing bypass risk: if anything
+    ever routes `awaiting_clear -> awaiting_human`, the clear boundary becomes
+    optional again.
+    """
+    cfg = tomllib.loads(TRANSITIONS_TOML.read_text())
+    sources_into_awaiting_human = {
+        t["from"] for t in cfg["transitions"] if t.get("to") == "awaiting_human"
+    }
+    assert "awaiting_clear" not in sources_into_awaiting_human, (
+        "awaiting_clear can reach awaiting_human, whose `resume` is ungated — "
+        "that is a route around the mandatory context reset (#79). Entries: "
+        f"{sorted(sources_into_awaiting_human)}"
+    )

--- a/tests/test_hook_output_schema.py
+++ b/tests/test_hook_output_schema.py
@@ -88,6 +88,14 @@ _EVENT_BUILDERS: dict[str, object] = {
         "cwd": cwd,
     },
     "UserPromptSubmit": lambda cwd: {"cwd": cwd, "user_prompt": "test"},
+    # `source` is the field that decides whether a context_reset is recorded
+    # at all (#79), so the representative event must carry a real one.
+    "SessionStart": lambda cwd: {
+        "cwd": cwd,
+        "session_id": "abc123",
+        "hook_event_name": "SessionStart",
+        "source": "clear",
+    },
 }
 
 

--- a/tests/test_primer.py
+++ b/tests/test_primer.py
@@ -137,62 +137,58 @@ class TestPrimerErrorMessageQuality:
 
 
 @pytest.mark.hook_e2e
-class TestPrimerContextResetRecording:
-    """context_reset is recorded via the daemon `record_event` socket op.
+class TestPrimerNeverRecordsContextReset:
+    """Issue #79 regression guard.
 
-    Regression coverage for the swallowed-returncode bug. In production the
-    daemon was REACHABLE but rejected the restricted-event submit (the bare
-    `sahjhan authed-event` courier could never resolve to a trusted hook →
-    pid_resolution_failed). The old CLI path returned that as a non-zero exit
-    code the primer never checked, so no context_reset landed AND no failure
-    surfaced. record_authed_event now records over the daemon socket and
-    raises on rejection, so both outcomes are observable.
+    The primer used to record `context_reset` on every UserPromptSubmit. That
+    event gates `awaiting_clear -> fix_loop`, and UserPromptSubmit fires on any
+    turn — an ordinary typed message, or an automated background-task
+    notification with no human and no /clear. So the gate opened with the full
+    recon+audit+merge context intact, silently, while `status` reported
+    `resume: ready`.
+
+    The recording now belongs to session_start.py, which fires only when the
+    host reports a real reset. The primer must never write it again, on any
+    prompt, under any daemon condition — otherwise the hole reopens.
     """
 
-    def test_daemon_rejection_injects_enforcement_failure(self, tmp_path, mock_daemon):
-        """Daemon reachable but rejects record_event → ENFORCEMENT FAILURE.
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            "continue",
+            "/clear",  # the text of a clear is not a clear
+            "<task-notification>subagent finished</task-notification>",
+        ],
+    )
+    def test_no_context_reset_for_any_prompt(self, tmp_path, mock_daemon, prompt):
+        _init_sahjhan(tmp_path)
 
-        This is the exact production scenario the old code swallowed.
+        event = {"cwd": str(tmp_path), "user_prompt": prompt}
+        code, _, _ = run_enforcement_hook("primer.py", event, cwd=str(tmp_path))
+        assert code == 0
+
+        resets = [
+            e for e in mock_daemon.recorded_events
+            if e.get("event_type") == "context_reset"
+        ]
+        assert not resets, (
+            f"primer recorded a context_reset for prompt {prompt!r}. A prompt is "
+            f"not a context reset — this is exactly issue #79. Got: {resets!r}"
+        )
+
+    def test_healthy_daemon_reports_no_enforcement_failure(self, tmp_path, mock_daemon):
+        """A reachable, authenticating daemon must not raise a false alarm.
+
+        The health probe replaced a write with an `enforcement_read`, and an
+        audit that hasn't cached state yet answers `not_found`. That is a
+        healthy daemon, not a broken one.
         """
         _init_sahjhan(tmp_path)
-        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
-        # Alive init PID → not a daemon death → enforcement-failure branch.
-        (sahjhan_dir / "daemon-init-pid").write_text(f"{os.getpid()}\n")
-        mock_daemon.record_event_response = {
-            "ok": False,
-            "error": "auth_failed",
-            "message": "caller not authenticated",
-            "reason": "pid_resolution_failed",
-        }
-
-        event = {"cwd": str(tmp_path)}
-        code, output, _ = run_enforcement_hook("primer.py", event, cwd=str(tmp_path))
-        assert code == 0
-        context = output.get("hookSpecificOutput", {}).get("additionalContext", "")
-        assert "ENFORCEMENT FAILURE" in context, (
-            f"a rejected context_reset must surface, not be swallowed. Got: {context!r}"
-        )
-        attempts = [
-            e for e in mock_daemon.recorded_events if e.get("event_type") == "context_reset"
-        ]
-        assert attempts, "primer should have attempted a context_reset record_event"
-        assert attempts[0]["op"] == "record_event"
-
-    def test_daemon_success_records_context_reset(self, tmp_path, mock_daemon):
-        """Daemon accepts record_event → context_reset recorded, no failure."""
-        _init_sahjhan(tmp_path)
-        # mock_daemon default response is ok:true.
 
         event = {"cwd": str(tmp_path)}
         code, output, _ = run_enforcement_hook("primer.py", event, cwd=str(tmp_path))
         assert code == 0
         context = output.get("hookSpecificOutput", {}).get("additionalContext", "")
         assert "ENFORCEMENT FAILURE" not in context, (
-            f"a successful record must not report failure. Got: {context!r}"
+            f"a healthy daemon must not report failure. Got: {context!r}"
         )
-        resets = [
-            e for e in mock_daemon.recorded_events if e.get("event_type") == "context_reset"
-        ]
-        assert len(resets) == 1, "primer should record exactly one context_reset"
-        assert resets[0]["op"] == "record_event"
-        assert resets[0]["fields"]["trigger"] == "user_prompt_submit"

--- a/tests/test_real_daemon_integration.py
+++ b/tests/test_real_daemon_integration.py
@@ -268,3 +268,82 @@ class TestStopHookWithRealState:
         # Terminated marker → exit_stop_allow (no output)
         decision = output.get("decision", "")
         assert decision != "block"
+
+
+class TestContextResetProvenanceWithRealDaemon:
+    """Issue #79 end-to-end: only a real reset writes `context_reset`.
+
+    The mock daemon accepts any field values, so it cannot show that the real
+    engine validates the event's provenance against `events.toml`. These tests
+    drive the actual binary, whose `record_event` op runs `validate_event_fields`
+    and whose caller auth resolves the hook by content hash.
+    """
+
+    @staticmethod
+    def _session_start(real_daemon, source):
+        event = {
+            "cwd": real_daemon["project_root"],
+            "hook_event_name": "SessionStart",
+            "source": source,
+        }
+        return run_enforcement_hook(
+            "session_start.py", event,
+            cwd=real_daemon["project_root"],
+            env=_hook_env(real_daemon),
+        )
+
+    @staticmethod
+    def _context_resets(real_daemon):
+        """Every context_reset in the active ledger, as field dicts."""
+        result = _run_sahjhan(real_daemon, "--json", "log", "dump")
+        entries = json.loads(result.stdout)["data"]["entries"]
+        return [
+            e.get("fields", {}) for e in entries
+            if e.get("event_type") == "context_reset"
+        ]
+
+    def test_clear_records_with_session_start_provenance(self, real_daemon):
+        """A real /clear lands a real event the real engine accepted."""
+        _run_sahjhan(real_daemon, "ledger", "create", "--from", "run", "1", "--activate")
+        _run_sahjhan(real_daemon, "transition", "run_start")
+
+        code, _, _ = self._session_start(real_daemon, "clear")
+        assert code == 0
+
+        resets = self._context_resets(real_daemon)
+        assert len(resets) == 1, f"expected one context_reset, got {resets!r}"
+        assert resets[0]["trigger"] == "session_start"
+        assert resets[0]["source"] == "clear"
+
+    def test_resume_source_records_nothing(self, real_daemon):
+        """`--resume` restores the transcript, so it is not a reset."""
+        _run_sahjhan(real_daemon, "ledger", "create", "--from", "run", "1", "--activate")
+        _run_sahjhan(real_daemon, "transition", "run_start")
+
+        code, _, _ = self._session_start(real_daemon, "resume")
+        assert code == 0
+        assert not self._context_resets(real_daemon), (
+            "a resumed session carries the prior context forward — recording "
+            "context_reset for it is issue #79 with extra steps"
+        )
+
+    def test_resume_gate_blocked_without_a_reset(self, real_daemon):
+        """The awaiting_clear gate reports blocked until a reset is recorded.
+
+        This is the assertion the reporter's live run needed: at awaiting_clear
+        with no reset, `gate check resume` must NOT say ready.
+        """
+        _run_sahjhan(real_daemon, "ledger", "create", "--from", "run", "1", "--activate")
+        result = _run_sahjhan(real_daemon, "--json", "gate", "check", "resume", check=False)
+
+        # Either sahjhan refuses the check (wrong source state) or reports it
+        # blocked — what must never happen is a `ready`/passing verdict with no
+        # context_reset in the ledger.
+        assert not self._context_resets(real_daemon)
+        if result.returncode == 0 and result.stdout.strip():
+            data = json.loads(result.stdout)
+            passed = data.get("data", {}).get("passed")
+            assert passed is not True, (
+                f"resume gate reported passing with zero context_reset events "
+                f"in the ledger — this is issue #79. Got: {data!r}"
+            )

--- a/tests/test_sahjhan_integration.py
+++ b/tests/test_sahjhan_integration.py
@@ -808,15 +808,18 @@ class TestPrimer:
         assert code == 0
         assert output.get("continue") is True
 
-    def test_records_context_reset_via_record_event_op(self):
-        """Primer records context_reset through the daemon `record_event` op.
+    def test_does_not_record_context_reset_on_prompt(self):
+        """Primer must not write context_reset on any UserPromptSubmit (#79).
 
-        Supersedes BH-008 (which checked the old `sahjhan authed-event
-        --field` CLI syntax). context_reset is no longer recorded via the CLI
-        at all — the primer asks the daemon to append it directly over the
-        authenticated socket. This test sets up a mock daemon at a short
-        socket path and asserts the append request arrived with the right
-        fields. Uses a short temp path to stay within macOS AF_UNIX limits.
+        History: BH-008 caught the primer using the wrong CLI syntax, and a
+        later fix moved the write to the daemon `record_event` op. Both were
+        about *how* the event was written. #79 is about *whether* it should be:
+        UserPromptSubmit fires on incidental turns and automated background-task
+        notifications, so recording there opened the awaiting_clear gate with the
+        pre-reset context intact. session_start.py owns the write now — this
+        test keeps the primer out of it, against a real daemon socket rather
+        than a stub, so "no record" cannot be an unreachable-socket artifact.
+        Uses a short temp path to stay within macOS AF_UNIX limits.
         """
         import shutil
         import tempfile
@@ -885,17 +888,15 @@ class TestPrimer:
         # The primer ran `sahjhan status` through the (mock) CLI binary...
         assert log_file.exists(), "primer should have invoked sahjhan status"
         assert "status" in log_file.read_text()
-        # ...but context_reset is recorded over the socket, not the CLI.
+        # ...and the daemon was reachable throughout, so an absent context_reset
+        # is a decision, not a dropped connection.
         resets = [
             e for e in daemon.recorded_events if e.get("event_type") == "context_reset"
         ]
-        assert resets, (
-            "primer should record a context_reset via the daemon record_event op "
-            "when an active non-terminal run exists"
+        assert not resets, (
+            "the primer must not record context_reset — a submitted prompt is not "
+            f"a context reset (#79). Got: {resets!r}"
         )
-        assert resets[0]["op"] == "record_event"
-        assert resets[0]["fields"].get("project") == "holtz"
-        assert resets[0]["fields"].get("trigger") == "user_prompt_submit"
 
     def test_degrades_gracefully_on_oserror(self, tmp_path):
         """BH-015: primer degrades gracefully when binary is unexecutable."""

--- a/tests/test_session_start.py
+++ b/tests/test_session_start.py
@@ -1,0 +1,263 @@
+"""Tests for session_start.py — the SessionStart hook (issue #79).
+
+The invariant under test: `context_reset` is recorded **iff the context was
+actually reset**. Before #79 it was recorded iff a prompt was submitted, so the
+`awaiting_clear -> fix_loop` gate opened on any incidental turn — including an
+automated background-task notification — with the pre-reset context intact.
+
+Everything here drives the hook by subprocess, which is the interface Claude
+Code actually uses (CLAUDE.md testing methodology, rule 2).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "enforcement", "hooks"))
+sys.path.insert(0, os.path.join(REPO_ROOT, "tests"))
+
+from _resolve import ensure_sahjhan  # noqa: E402
+from test_sahjhan_integration import (  # noqa: E402
+    _create_mock_binary,
+    _mock_env,
+    run_enforcement_hook,
+)
+
+SAHJHAN = ensure_sahjhan()
+CONFIG_DIR = os.path.join(REPO_ROOT, "enforcement")
+
+pytestmark = pytest.mark.skipif(
+    SAHJHAN is None, reason="sahjhan binary not available"
+)
+
+# Sources that wipe or replace the context. The hook must record for these.
+RESET_SOURCES = ["clear", "compact", "startup"]
+# Sources that carry the prior transcript forward. The hook must stay silent.
+NON_RESET_SOURCES = ["resume", "fork"]
+
+
+def _init_sahjhan(tmp_path):
+    """Initialize a sahjhan working dir so `status` reports a live run."""
+    subprocess.run(
+        [SAHJHAN, "--config-dir", CONFIG_DIR, "init"],
+        capture_output=True, text=True, timeout=5, cwd=str(tmp_path),
+        check=True,
+    )
+    ledger_path = str(tmp_path / "run-1.jsonl")
+    subprocess.run(
+        [SAHJHAN, "--config-dir", CONFIG_DIR, "ledger", "create",
+         "--name", "run-1", "--path", ledger_path],
+        capture_output=True, text=True, timeout=5, cwd=str(tmp_path),
+        check=True,
+    )
+
+
+def _resets(daemon):
+    return [
+        e for e in daemon.recorded_events if e.get("event_type") == "context_reset"
+    ]
+
+
+def _run(tmp_path, source: str | None):
+    event: dict = {"cwd": str(tmp_path), "hook_event_name": "SessionStart"}
+    if source is not None:
+        event["source"] = source
+    return run_enforcement_hook("session_start.py", event, cwd=str(tmp_path))
+
+
+@pytest.mark.hook_e2e
+class TestRecordsOnlyOnRealReset:
+    """`source` decides whether the reset happened. Nothing else does."""
+
+    @pytest.mark.parametrize("source", RESET_SOURCES)
+    def test_records_for_reset_source(self, tmp_path, mock_daemon, source):
+        """clear/compact/startup all leave the model with no prior context."""
+        _init_sahjhan(tmp_path)
+
+        code, _, _ = _run(tmp_path, source)
+        assert code == 0
+
+        resets = _resets(mock_daemon)
+        assert len(resets) == 1, (
+            f"SessionStart source={source!r} is a real context reset and must "
+            f"record exactly one context_reset. Got: {resets!r}"
+        )
+        assert resets[0]["op"] == "record_event"
+
+    @pytest.mark.parametrize("source", NON_RESET_SOURCES)
+    def test_no_record_for_non_reset_source(self, tmp_path, mock_daemon, source):
+        """resume restores the transcript; fork copies it. Neither is a reset."""
+        _init_sahjhan(tmp_path)
+
+        code, _, _ = _run(tmp_path, source)
+        assert code == 0
+        assert not _resets(mock_daemon), (
+            f"SessionStart source={source!r} carries the prior context forward — "
+            f"recording context_reset would reopen the #79 hole."
+        )
+
+    def test_no_record_when_source_missing(self, tmp_path, mock_daemon):
+        """An absent `source` is not evidence of anything. Fail closed."""
+        _init_sahjhan(tmp_path)
+
+        code, _, _ = _run(tmp_path, None)
+        assert code == 0
+        assert not _resets(mock_daemon), (
+            "a SessionStart payload with no `source` proves nothing about the "
+            "context and must not satisfy the awaiting_clear gate"
+        )
+
+    def test_no_record_for_unknown_source(self, tmp_path, mock_daemon):
+        """A source Claude Code adds later must not silently count as a reset."""
+        _init_sahjhan(tmp_path)
+
+        code, _, _ = _run(tmp_path, "teleport")
+        assert code == 0
+        assert not _resets(mock_daemon), (
+            "unknown sources must fail closed — an allowlist, not a denylist"
+        )
+
+
+@pytest.mark.hook_e2e
+class TestRecordedProvenance:
+    """The event carries the provenance the `resume` gate filters on."""
+
+    def test_fields_identify_the_reset(self, tmp_path, mock_daemon):
+        _init_sahjhan(tmp_path)
+
+        _run(tmp_path, "compact")
+
+        fields = _resets(mock_daemon)[0]["fields"]
+        assert fields["trigger"] == "session_start", (
+            "transitions.toml filters the resume gate on trigger=session_start; "
+            "any other value silently disables the gate"
+        )
+        assert fields["source"] == "compact"
+        assert fields["project"] == "holtz"
+        assert fields["auditor"] == "holtz"
+        assert fields["run"].isdigit()
+
+
+@pytest.mark.hook_e2e
+class TestNoActiveRun:
+    """No audit, or a dead one — stay out of the way."""
+
+    def test_silent_without_sahjhan_dir(self, tmp_path, mock_daemon):
+        """No docs/holtz/.sahjhan → nothing to record, no binary bootstrap.
+
+        Runs from a sibling dir: the mock_daemon fixture creates .sahjhan under
+        tmp_path itself, and the daemon must stay reachable so "no record" is a
+        real observation rather than an unreachable-socket artifact.
+        """
+        no_audit = tmp_path / "elsewhere"
+        no_audit.mkdir()
+
+        code, output, _ = _run(no_audit, "clear")
+        assert code == 0
+        assert not _resets(mock_daemon)
+        assert output.get("hookSpecificOutput", {}).get("additionalContext", "") == ""
+
+    def test_silent_when_audit_terminated(self, tmp_path, mock_daemon):
+        """The primer announces termination on the next prompt — don't double it."""
+        _init_sahjhan(tmp_path)
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        (sahjhan_dir / "terminated").write_text("reason: daemon_pid_dead\n")
+
+        code, output, _ = _run(tmp_path, "clear")
+        assert code == 0
+        assert not _resets(mock_daemon)
+        assert output.get("hookSpecificOutput", {}).get("additionalContext", "") == ""
+
+
+@pytest.mark.hook_e2e
+class TestFailureSurfaces:
+    """A context_reset that never landed strands the run in awaiting_clear."""
+
+    def test_daemon_rejection_injects_enforcement_failure(self, tmp_path, mock_daemon):
+        """Daemon reachable but rejects record_event → ENFORCEMENT FAILURE.
+
+        Moved from the primer with the recording itself. The production bug it
+        guards: the daemon refuses an unlisted/stale-hash caller, the write is
+        swallowed, and nothing surfaces.
+        """
+        _init_sahjhan(tmp_path)
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        # Alive init PID → not a daemon death → enforcement-failure branch.
+        (sahjhan_dir / "daemon-init-pid").write_text(f"{os.getpid()}\n")
+        mock_daemon.record_event_response = {
+            "ok": False,
+            "error": "auth_failed",
+            "message": "caller not authenticated",
+            "reason": "pid_resolution_failed",
+        }
+
+        code, output, _ = _run(tmp_path, "clear")
+        assert code == 0
+        context = output.get("hookSpecificOutput", {}).get("additionalContext", "")
+        assert "ENFORCEMENT FAILURE" in context, (
+            f"a rejected context_reset must surface, not be swallowed. Got: {context!r}"
+        )
+
+    def test_dead_daemon_writes_terminated_marker(self, tmp_path):
+        """Dead init PID → terminated marker + termination message, no restart."""
+        _init_sahjhan(tmp_path)
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        (sahjhan_dir / "daemon-init-pid").write_text("99999999\n")
+
+        code, output, _ = _run(tmp_path, "clear")
+        assert code == 0
+        assert (sahjhan_dir / "terminated").exists()
+        context = output.get("hookSpecificOutput", {}).get("additionalContext", "")
+        assert "AUDIT TERMINATED" in context
+        assert "/stop" not in context, (
+            f"/stop is not a real Claude Code command (issue #55). Got: {context!r}"
+        )
+
+    def test_output_is_session_start_shaped(self, tmp_path):
+        """SessionStart cannot block — output must never carry a decision."""
+        _init_sahjhan(tmp_path)
+        sahjhan_dir = tmp_path / "docs" / "holtz" / ".sahjhan"
+        (sahjhan_dir / "daemon-init-pid").write_text("99999999\n")
+
+        _, output, _ = _run(tmp_path, "clear")
+        assert "decision" not in output
+        hso = output.get("hookSpecificOutput", {})
+        assert hso.get("hookEventName") == "SessionStart"
+
+
+@pytest.mark.hook_e2e
+class TestRunStateGuards:
+    """No live run to reset — record nothing, say nothing."""
+
+    def _mock_run(self, tmp_path, status_body):
+        (tmp_path / "enforcement").mkdir(parents=True, exist_ok=True)
+        _create_mock_binary(tmp_path, status_body)
+        event = {
+            "cwd": str(tmp_path),
+            "hook_event_name": "SessionStart",
+            "source": "clear",
+        }
+        return run_enforcement_hook(
+            "session_start.py", event, cwd=str(tmp_path), env=_mock_env(tmp_path),
+        )
+
+    def test_no_record_in_terminal_state(self, tmp_path, mock_daemon):
+        """A finished run has nothing to resume — don't append to its ledger."""
+        code, _, _ = self._mock_run(
+            tmp_path, 'echo "state: finalized (12 events, chain valid)"'
+        )
+        assert code == 0
+        assert not _resets(mock_daemon), (
+            "recording a context_reset into a terminal run is noise the resume "
+            "gate can never consume"
+        )
+
+    def test_no_record_when_status_fails(self, tmp_path, mock_daemon):
+        """If sahjhan can't report state, claim nothing about the context."""
+        code, _, _ = self._mock_run(tmp_path, "exit 1")
+        assert code == 0
+        assert not _resets(mock_daemon)

--- a/tests/test_verify_hooks.py
+++ b/tests/test_verify_hooks.py
@@ -56,6 +56,11 @@ def test_passes_with_all_hooks(tmp_path):
                 {"type": "command", "command": "python enforcement/hooks/primer.py"},
             ]},
         ],
+        "SessionStart": [
+            {"matcher": "", "hooks": [
+                {"type": "command", "command": "python enforcement/hooks/session_start.py"},
+            ]},
+        ],
         "Stop": [
             {"matcher": "", "hooks": [
                 {"type": "command", "command": "python enforcement/hooks/stop_hook.py"},


### PR DESCRIPTION
Closes #79 — a P1 enforcement-integrity bug: the one HARD-GATE that keeps the fix loop from starting in an oversized context was a no-op.

## The bug

`context_reset` gates `awaiting_clear -> fix_loop`. `primer.py` recorded it on **every** `UserPromptSubmit` — a category error about what the hook event means. `UserPromptSubmit` answers "did a turn begin?", not "was the context wiped?", and it fires on ordinary messages and on automated background-task notifications alike. So the gate opened on whatever prompt arrived next, carrying the entire recon+audit+merge context into the fix loop — exactly the state the boundary exists to prevent.

It failed silently and *looked* like success: `status` printed `resume: ready` and the resume banner was injected, so nothing signalled that no reset had happened. It was also non-deterministic in a bad way — whether the gate opened "correctly" depended on background-task timing.

## The fix

Record from `SessionStart`, the event that actually corresponds to a wiped context. Two properties make it the right source of truth:

- **Host-driven** — no tool call produces a `SessionStart`, so an agent cannot manufacture the evidence.
- **Self-describing** — its `source` field distinguishes a real wipe from a restore.

| `source` | Recorded | Rationale |
|---|---|---|
| `clear` | ✅ | `/clear` — context wiped |
| `compact` | ✅ | context replaced by a summary |
| `startup` | ✅ | new session — context cannot be present |
| `resume` | ❌ | `--resume`/`--continue` restores the transcript |
| `fork` | ❌ | `--fork-session`/`/fork`/`/branch` copies it forward |

`startup` goes beyond what the issue suggested, deliberately: excluding it would trade this bug for #73's failure mode, deadlocking anyone who relaunches Claude Code at `awaiting_clear` with a genuinely empty context.

### Three layers, so one revert can't silently reopen it

| Layer | Decides | Change |
|---|---|---|
| `enforcement/hooks/session_start.py` (new) | whether a reset happened | allowlist on `source`; absent/unknown fails closed |
| `enforcement/events.toml` | what may be written | `trigger` → `^session_start$`; required `source` patterned to the reset sources |
| `enforcement/transitions.toml` | what counts as evidence | `resume` gate gains `filter = { trigger = "session_start" }` |

The daemon validates event fields on every `record_event`, so `trigger=user_prompt_submit` is now **unwritable**, not merely unused — and because the gate filters on provenance, the events already sitting in live ledgers can't satisfy it either.

**In-flight impact:** an audit parked in `awaiting_clear` across this upgrade needs an actual `/clear` to proceed. That is the behavior the gate always claimed.

## Incidental fixes on the same path

- **`DaemonError`** — the primer's death and auth banners were side effects of the write being removed. Replacing them needed a probe that distinguishes `auth_failed` (enforcement broken) from `not_found` (nothing cached yet), but `_daemon_request` was collapsing every refusal into its prose message, leaving only string-matching — the brittle-mirror pattern behind #77. It now raises `DaemonError` carrying the wire `error` code; subclassing `RuntimeError` keeps existing handlers unchanged. The death check also improved to a direct init-PID probe on every prompt.
- **Smoke-test roster** — `scripts/smoke-test-hooks.sh` uses a hardcoded hook list, so the release gate reported 9/9 green while never invoking the new hook. Now 10/10, with `session_start` exercised through a real `claude -p` run.

## No sahjhan change

Everything needed already ships in 0.19.0: `restricted` events + the daemon `record_event` op, per-field pattern validation, and `ledger_has_event_since` with a payload `filter`. Teaching the engine about `SessionStart`/`source` would push Claude Code host-lifecycle semantics into a generic state machine, so the fix stayed in holtz config plus one hook.

## Verification (observed)

Against a **live real daemon**, not a mock: the hook authenticated as `hooks/session_start.py` and appended `context_reset` with `trigger=session_start, source=clear` to the run ledger.

- dev CI run [30168904823](https://github.com/jbrjake/holtz/actions/runs/30168904823) — `conclusion=success`
- `scripts/pre-release-check.sh` — **ALL PASSED**: ruff, mypy, contract gate, schema freshness, sahjhan pin, full suite (1791 passed / 8 skipped, **91.27%** coverage), hook smoke test 10/10, version bump
- New tests: 15 `hook_e2e`, 3 real-daemon, 7 declarative-config — including one keeping the deliberately-ungated `awaiting_human` `resume` unreachable from `awaiting_clear`, since it shares the command name

**Not verified:** a full end-to-end audit driven through an actual `/clear` in a live session. The `SessionStart` wiring is verified by hook subprocess, real daemon, and a live `claude -p` smoke run — not by an observed live clear.

Design notes: `docs/superpowers/plans/2026-07-25-issue-79-context-reset-provenance.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AroNKu1Mf49TWb7FQmCRTk
